### PR TITLE
Fixed out of date RVM url

### DIFF
--- a/mac
+++ b/mac
@@ -36,7 +36,7 @@ echo "Installing QT, used by Capybara Webkit for headless Javascript integration
   brew install qt
 
 echo "Installing RVM (Ruby Version Manager) ..."
-  curl -s https://rvm.beginrescueend.com/install/rvm -o rvm-installer ; chmod +x rvm-installer ; ./rvm-installer --version latest
+  bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
   echo "
 # RVM
 [[ -s '/Users/`whoami`/.rvm/scripts/rvm' ]] && source '/Users/`whoami`/.rvm/scripts/rvm'" >> ~/.zshrc


### PR DESCRIPTION
RVM wasn't being installed as the link used in the mac file had been deprecated.
As a result Rails was installed to the base system and the RVM commands used in the script weren't working either.
