### PR TITLE
removed outdated gist of homebrew install script. now installs homebrew ...

### DIFF
--- a/mac
+++ b/mac
@@ -8,7 +8,7 @@ echo "Copying public key to clipboard. Paste it into your Github account ..."
   open https://github.com/account/ssh
 
 echo "Installing Homebrew, a good OS X package manager ..."
-  /usr/bin/ruby -e "$(curl -fsSL https://raw.github.com/gist/323731)"
+  /usr/bin/ruby -e "$(/usr/bin/curl -fksSL https://raw.github.com/mxcl/homebrew/master/Library/Contributions/install_homebrew.rb)"
   brew update
 
 echo "Put Homebrew location earlier in PATH ..."


### PR DESCRIPTION
...using recommended command line invocation as here https://github.com/mxcl/homebrew/wiki/installation
