### PR TITLE
depend on zsh publicly, and sh where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ if you're on Lion (OS X 10.7).
 
 Run the script:
 
-    bash < <(curl -s https://raw.github.com/thoughtbot/laptop/master/mac)
+    zsh < <(curl -s https://raw.github.com/thoughtbot/laptop/master/mac)
 
 What it sets up
 ---------------

--- a/heroku
+++ b/heroku
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Installing the heroku-accounts plugin for using multiple Heroku accounts..."
   heroku plugins:install git://github.com/ddollar/heroku-accounts.git
 

--- a/mac
+++ b/mac
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 
 echo "Checking for SSH key, generating one if it doesn't exist ..."
   [[ -f ~/.ssh/id_rsa.pub ]] || ssh-keygen -t rsa
@@ -42,5 +42,5 @@ echo "Installing RVM (Ruby Version Manager) ..."
 [[ -s '/Users/`whoami`/.rvm/scripts/rvm' ]] && source '/Users/`whoami`/.rvm/scripts/rvm'" >> ~/.zshrc
   source ~/.zshrc
 
-bash < <(curl -s https://raw.github.com/thoughtbot/laptop/master/ruby)
-bash < <(curl -s https://raw.github.com/thoughtbot/laptop/master/heroku)
+zsh < <(curl -s https://raw.github.com/thoughtbot/laptop/master/ruby)
+zsh < <(curl -s https://raw.github.com/thoughtbot/laptop/master/heroku)

--- a/ruby
+++ b/ruby
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo "Installing Ruby 1.9.2 stable and making it the default Ruby ..."
   rvm install 1.9.2-p290
   rvm use 1.9.2 --default


### PR DESCRIPTION
Since zsh is a requirement, don't depend on bash everywhere, and especially not in the README. This drops down to sh where possible.
