### PR TITLE
Upgrade Ruby and Bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ What it sets up
 * Postgres gem for talking to Postgres from Ruby
 * Qt for headless JavaScript testing via Capybara Webkit
 * Rails gem for writing web applications
-* Ruby 1.9.2 stable for writing general-purpose code
+* Ruby 1.9.3 stable for writing general-purpose code
 * RVM for managing versions of the Ruby programming language
 * SSH public key for authenticating with Github and Heroku
 * Tmux for saving project state and switching between projects

--- a/ruby
+++ b/ruby
@@ -1,8 +1,11 @@
 #!/bin/sh
 
-echo "Installing Ruby 1.9.2 stable and making it the default Ruby ..."
-  rvm install 1.9.2-p290 --with-gcc=clang
-  rvm use 1.9.2 --default
+echo "Installing Ruby 1.9.3 stable and making it the default Ruby ..."
+  rvm install 1.9.3 --with-gcc=clang
+  rvm use 1.9.3 --default
+
+echo "Installing Bundler to build gem dependencies ..."
+  gem install bundler -v 1.2.0.rc.2 --no-rdoc --no-ri
 
 echo "Installing Rails to write and run web applications ..."
   gem install rails --no-rdoc --no-ri


### PR DESCRIPTION
- Ruby 1.9.3 is working well for us on real apps in Heroku production.
- Bundler 1.2.0.rc2 provides a `ruby` directive that is becoming our
  standard for defining the Ruby version for the project.
