### PR TITLE
Remove unnecessary Ruby version install

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ What it sets up
 * Postgres gem for talking to Postgres from Ruby
 * Qt for headless JavaScript testing via Capybara Webkit
 * Rails gem for writing web applications
-* Ruby 1.9.3 stable for writing general-purpose code
+* Ruby stable for writing general-purpose code
 * RVM for managing versions of the Ruby programming language
 * SSH public key for authenticating with Github and Heroku
 * Tmux for saving project state and switching between projects

--- a/ruby
+++ b/ruby
@@ -1,9 +1,5 @@
 #!/bin/sh
 
-echo "Installing Ruby 1.9.3 stable and making it the default Ruby ..."
-  rvm install 1.9.3 --with-gcc=clang
-  rvm use 1.9.3 --default
-
 echo "Installing Bundler to build gem dependencies ..."
   gem install bundler -v '~> 1.2.0.rc.2' --no-rdoc --no-ri
 


### PR DESCRIPTION
RVM automatically installs the stable version of Ruby so we don't need
to explicitly set a Ruby version.

The current version of RVM installs Ruby 1.9.3p194.
