### PR TITLE
Remove deprectated Heroku gem, add CLI client

### DIFF
--- a/mac
+++ b/mac
@@ -60,7 +60,7 @@ echo "Installing critical Ruby gems for Rails development ..."
   successfully gem install bundler rails pg foreman thin --no-rdoc --no-ri
 
 echo "Installing standalone Heroku CLI client. You'll need administrative rights on your machine ..."
-  successfully wget -qO- https://toolbelt.heroku.com/install.sh | sh
+  successfully curl -s https://toolbelt.heroku.com/install.sh | sh
 
 echo "Installing the heroku-config plugin for pulling config variables locally to be used as ENV variables ..."
   successfully heroku plugins:install git://github.com/ddollar/heroku-config.git


### PR DESCRIPTION
The Heroku gem has been deprecated, and Heroku recommends installing the client CLI from toolbelt.heroku.com. It's a binary, but you can install the "standalone" version (https://toolbelt.heroku.com/standalone) via wget.
