### PR TITLE
Mkdir /usr/local for Homebrew if it doesn't exist

### DIFF
--- a/mac
+++ b/mac
@@ -12,6 +12,7 @@ echo "Copying public key to clipboard. Paste it into your Github account ..."
   successfully open https://github.com/account/ssh
 
 echo "Fixing permissions ..."
+  successfully sudo mkdir -p /usr/local
   successfully sudo chown -R `whoami` /usr/local
 
 echo "Installing Homebrew, a good OS X package manager ..."


### PR DESCRIPTION
I hit an error when running the laptop script on a new Mountain Lion install.

`chown: /usr/local: No such file or directory`

Homebrew will create and set the mode of the directory, but if we want to chown it for the user prior to installing Homebrew we might need to create it first.

Using `mkdir -p` to only create if it doesn't exist.
