### PR TITLE
Use rbenv to change Ruby versions

### DIFF
--- a/mac
+++ b/mac
@@ -65,7 +65,7 @@ echo "Installing rbenv for changing Ruby versions ..."
   successfully echo 'eval "$(rbenv init -)"' >> ~/.zlogin
   successfully source ~/.zlogin
 
-echo "Installing rbenv-gem-rehash so the shell automatically picks up binareis after installing gems with binaries..."
+echo "Installing rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
   successfully brew install rbenv-gem-rehash
 
 echo "Installing ruby-build for installing Rubies ..."


### PR DESCRIPTION
- Use Homebrew consistently for OS programs.
- Use ruby-build to install Rubies.
- Include auto-switching of Ruby in `~/.zlogin`.
- Install latest stable version of Ruby (2.0).
- Upgrade Rubygems after Ruby is installed. This is to help avoid common
  Bundler/Psych issues:
  https://github.com/tenderlove/psych/issues/66
- Use Bundler prerelease version for now in order to work with latest
  Rubygems on Ruby 2.0.
