### PR TITLE
Force gcc-4.2 compiler when installing Ruby

### DIFF
--- a/mac
+++ b/mac
@@ -72,7 +72,7 @@ echo "Installing ruby-build for installing Rubies ..."
   successfully brew install ruby-build
 
 echo "Installing Ruby 1.9.3-p392 ..."
-  successfully rbenv install 1.9.3-p392
+  successfully CC=gcc-4.2 rbenv install 1.9.3-p392
 
 echo "Setting Ruby 1.9.3-p392 as global default Ruby ..."
   successfully rbenv global 1.9.3-p392


### PR DESCRIPTION
Avoid errors like:

```
st.c:520:35: error: implicit conversion loses integer precision:
```

   'st_index_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
   i = table->num_entries++; ~ ~~~~~~~~~~~~~~~~~~^~

https://github.com/sstephenson/ruby-build/issues/287
