### PR TITLE
Install The Silver Searcher instead of Ack

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Run the script:
 What it sets up
 ---------------
 
-* Ack for finding things in files
 * Bundler gem for managing Ruby libraries
 * Exuberant Ctags for indexing files for vim tab completion
 * Foreman gem for serving Rails apps locally
@@ -45,6 +44,7 @@ What it sets up
 * Ruby Build for installing Rubies
 * Ruby stable for writing general-purpose code
 * SSH public key for authenticating with Github and Heroku
+* The Silver Searcher for finding things in files
 * Tmux for saving project state and switching between projects
 * Watch for periodically executing a program and displaying the output
 

--- a/mac
+++ b/mac
@@ -39,8 +39,8 @@ echo "Installing Postgres, a good open source relational database ..."
 echo "Installing Redis, a good key-value database ..."
   successfully brew install redis
 
-echo "Installing ack, for searching the contents of files ..."
-  successfully brew install ack
+echo "Installing The Silver Searcher (better than ack or grep) for searching the contents of files ..."
+  successfully brew install the_silver_searcher
 
 echo "Installing ctags, for indexing files for vim tab completion of methods, classes, variables ..."
   successfully brew install ctags


### PR DESCRIPTION
https://github.com/ggreer/the_silver_searcher
- ag searches faster than ack
- ag searches all files by default (but still ignores gitignored files).
  This removes the need for ack's --type-add= options.
