### PR TITLE
Fix rbenv install

### DIFF
--- a/mac
+++ b/mac
@@ -76,15 +76,16 @@ echo "Installing Ruby 1.9.3-p392 ..."
 
 echo "Setting Ruby 1.9.3-p392 as global default Ruby ..."
   successfully rbenv global 1.9.3-p392
+  successfully rbenv shell 1.9.3-p392
 
 echo "Update to latest Rubygems version ..."
   successfully gem update --system
 
 echo "Installing critical Ruby gems for Rails development ..."
-  successfully gem install bundler foreman pg rails thin --no-rdoc --no-ri
+  successfully gem install bundler foreman pg rails thin --no-document
 
 echo "Installing GitHub CLI client ..."
-  successfully gem install hub
+  successfully gem install hub --no-document
 
 echo "Installing Heroku CLI client ..."
   successfully brew install heroku-toolbelt


### PR DESCRIPTION
Error was:

```
command not found: CC=gcc-4.2
```
