### PR TITLE
Prevent repeat dotfile edits and a more pleasant UX

### DIFF
--- a/mac
+++ b/mac
@@ -43,7 +43,7 @@ successfully brew install redis
 # files.
 successfully brew install the_silver_searcher
 
-# Instal ctags to index files for vim tab completion of methods, classes,
+# Install ctags to index files for vim tab completion of methods, classes,
 # variables.
 successfully brew install ctags
 


### PR DESCRIPTION
## Updates
- Remove check for SSH key before copying. This shouldn't fail unless the previous keygen step fails, in which case this doesn't matter
- Check for existing dotfile changes before repeating them. Ensures idempotency of the script. Applies to Homebrew path priority change and rbenv init call.
## UX
- Add intro and pause at beginning (e.g. 'hit return to start')
- Clearer description of browser-opening step. Browser opening can surprise people. This gives you some context.
- Add trailing echo's to separate output
- Add pause and instructions for setting up dbs at boot
- Give a 'hit return to continue' to give users time to read
- Instruct them on how to set up DBs to start at boot
