### PR TITLE
Use conventional zhs dotfile names

### DIFF
--- a/mac
+++ b/mac
@@ -5,7 +5,7 @@ successfully() {
 }
 
 echo "Fix OSX zsh environment bug"
-  successfully sudo mv /etc/{zshenv,zprofile}
+  successfully sudo mv /etc/{zshenv,zshrc}
 
 echo "Checking for SSH key, generating one if it doesn't exist ..."
   [[ -f ~/.ssh/id_rsa.pub ]] || ssh-keygen -t rsa


### PR DESCRIPTION
- rbenv documentation recommends .zshrc
- less files for us to manage in our home directory
- zprofile is just an alternative for ksh fans [source](http://zsh.sourceforge.net/Intro/intro_3.html)
- Tim Pope recommends moving /etc/zshenv to /etc/zshrc [source](https://github.com/tpope/vim-rbenv)
