### PR TITLE
Restore feature parity to linux and mac (now with better diffs!)

### DIFF
--- a/linux
+++ b/linux
@@ -3,13 +3,16 @@ CLEAR="\033[0m"
 ORANGE="\033[33m"
 
 successfully() {
-  $* || (echo "failed" 1>&2 && exit 1)
+  $* || (echo "\nfailed" 1>&2 && exit 1)
 }
 
 fancy_echo() {
   echo -e ${ORANGE}$1${CLEAR}
   echo
 }
+
+
+# Linux Specific
 
 if lsb_release -c | grep -qEv 'precise|quantal|wheezy'
 then
@@ -27,37 +30,28 @@ fancy_echo "Updating system packages ..."
   successfully sudo aptitude update
   successfully sudo aptitude -y dist-upgrade
 
-fancy_echo "Installing curl for transferring data with URL syntax ..."
-  successfully sudo aptitude -y curl
+fancy_echo "Install curl for transferring data with URL syntax ..."
+  successfully sudo aptitude install -y curl
 
-fancy_echo "Installing xclip for clipboard integration with your terminal ..."
-  successfully sudo aptitude install -y xclip
-
-fancy_echo "Installing git, for source control management ..."
+fancy_echo "Install git, for source control management ..."
   successfully sudo aptitude install -y git
 
-fancy_echo "Checking for SSH key, generating one if it doesn't exist ..."
-  [[ -f ~/.ssh/id_rsa.pub ]] || ssh-keygen -t rsa
-
-fancy_echo "Copying public key to clipboard. Paste it into your Github account ..."
-  [[ -f ~/.ssh/id_rsa.pub ]] && cat ~/.ssh/id_rsa.pub | xclip -selection clipboard
-  successfully x-www-browser https://github.com/account/ssh
+fancy_echo "Installing vim ..."
+  successfully sudo aptitude install -y vim-gtk
 
 fancy_echo "Installing base ruby build dependencies ..."
   successfully sudo aptitude build-dep -y ruby1.9.3
 
-fancy_echo "Installing libraries for common gem dependencies ..."
-# libxslt1-dev for nokogiri, libcurl4-openssl-dev for passenger standalone,
-# libksba8 for encryption, libqtwebkit-dev for capybara-webkit
-  successfully sudo aptitude install -y libxslt1-dev libcurl4-openssl-dev libksba8 libksba-dev libqtwebkit-dev
 
-fancy_echo "Installing Postgres, a good open source relational database ..."
+# Cross platform
+
+fancy_echo "Install Postgres, a good open source relational database ..."
   successfully sudo aptitude install -y postgresql postgresql-server-dev-all
 
-fancy_echo "Installing Redis, a good key-value database ..."
+fancy_echo "Install Redis, a good key-value database ..."
   successfully sudo aptitude install -y redis-server
 
-fancy_echo "Installing The Silver Searcher (better than ack or grep) for searching the contents of files ..."
+fancy_echo "Install The Silver Searcher (better than ack or grep) for searching the contents of files ..."
   successfully git clone git://github.com/ggreer/the_silver_searcher.git /tmp/the_silver_searcher
   successfully sudo aptitude install -y automake pkg-config libpcre3-dev zlib1g-dev
   successfully sh /tmp/the_silver_searcher/build.sh
@@ -67,55 +61,67 @@ fancy_echo "Installing The Silver Searcher (better than ack or grep) for searchi
   successfully cd ~
   successfully rm -rf /tmp/the_silver_searcher
 
-fancy_echo "Installing ctags, for indexing files for vim tab completion of methods, classes, variables ..."
+fancy_echo "Install ctags, for indexing files for vim tab completion of methods, classes, variables ..."
   successfully sudo aptitude install -y exuberant-ctags
 
-fancy_echo "Installing vim ..."
-  successfully sudo aptitude install -y vim-gtk
-
-fancy_echo "Installing tmux, for saving project state and switching between projects ..."
+fancy_echo "Install tmux, for saving project state and switching between projects ..."
   successfully sudo aptitude install -y tmux
 
-fancy_echo "Installing ImageMagick, for cropping and re-sizing images ..."
+fancy_echo "Install ImageMagick, for cropping and re-sizing images ..."
   successfully sudo aptitude install -y imagemagick
 
-fancy_echo "Installing watch, used to execute a program periodically and show the output ..."
+fancy_echo "Install QT, used by Capybara Webkit for headless Javascript integration testing ..."
+  successfully sudo aptitude install -y libqtwebkit-dev
+
+fancy_echo "Install watch, used to execute a program periodically and show the output ..."
   successfully sudo aptitude install -y watch
 
-fancy_echo "Installing rbenv for changing Ruby versions ..."
+fancy_echo "Install rbenv for changing Ruby versions ..."
   successfully git clone git://github.com/sstephenson/rbenv.git ~/.rbenv
-  successfully echo "export SHELL=$(which zsh)" >> ~/.zshrc
-  successfully echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.zshrc
-  successfully echo 'eval "$(rbenv init -)"' >> ~/.zshrc
-  successfully source ~/.zshrc
+  if ! grep -qs "PATH=.*rbenv" ~/.zshrc; then
+    successfully echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.zshrc
+  fi
+  if ! grep -qs "SHELL=.*zsh" ~/.zshrc; then
+    successfully echo "export SHELL=$(which zsh)" >> ~/.zshrc
+  fi
+  if ! grep -qs "rbenv init" ~/.zshrc; then
+    successfully echo 'eval "$(rbenv init -)"' >> ~/.zshrc
 
-fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
+    fancy_echo "Enable shims and autocompletion ..."
+      successfully eval "$(rbenv init -)"
+  fi
+
+  source ~/.zshrc
+
+fancy_echo "Install rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
   successfully git clone https://github.com/sstephenson/rbenv-gem-rehash.git ~/.rbenv/plugins/rbenv-gem-rehash
 
-fancy_echo "Installing ruby-build for installing Rubies ..."
+fancy_echo "Install ruby-build for installing Rubies ..."
   successfully git clone git://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
 
-fancy_echo "Installing Ruby 1.9.3-p392 ..."
+fancy_echo "Install Ruby 1.9.3-p392 ..."
   successfully rbenv install 1.9.3-p392
 
-fancy_echo "Setting Ruby 1.9.3-p392 as global default Ruby ..."
+fancy_echo "Set Ruby 1.9.3-p392 as global default Ruby ..."
   successfully rbenv global 1.9.3-p392
   successfully rbenv shell 1.9.3-p392
 
 fancy_echo "Update to latest Rubygems version ..."
   successfully gem update --system
 
-fancy_echo "Installing critical Ruby gems for Rails development ..."
+fancy_echo "Install critical Ruby gems for Rails development ..."
   successfully gem install bundler foreman pg rails thin --no-document
 
-fancy_echo "Installing GitHub CLI client ..."
+fancy_echo "Install GitHub CLI client ..."
   successfully gem install hub --no-document
 
-fancy_echo "Installing Heroku CLI client ..."
+fancy_echo "Install Heroku CLI client ..."
   successfully wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh
 
-fancy_echo "Installing the heroku-config plugin for pulling config variables locally to be used as ENV variables ..."
+fancy_echo "Install the heroku-config plugin for pulling config variables locally to be used as ENV variables ..."
   successfully heroku plugins:install git://github.com/ddollar/heroku-config.git
 
-fancy_echo "Your shell will now restart in order for changes to apply."
-  exec `which zsh` -l
+if ! grep -qs "DO NOT EDIT BELOW THIS LINE" ~/.zshrc; then
+  fancy_echo "Prepare ~/.zshrc for http://github.com/thoughtbot/dotfiles ..."
+    successfully echo "# DO NOT EDIT BELOW THIS LINE\n" >> ~/.zshrc
+fi

--- a/linux-prerequisites
+++ b/linux-prerequisites
@@ -3,7 +3,7 @@ CLEAR="\033[0m"
 ORANGE="\033[33m"
 
 successfully() {
-  $* || (echo "failed" 1>&2 && exit 1)
+  $* || (echo "\nfailed" 1>&2 && exit 1)
 }
 
 fancy_echo() {
@@ -14,7 +14,7 @@ fancy_echo() {
 if lsb_release -c | grep -qEv 'precise|quantal|wheezy'
 then
   fancy_echo "Sorry! we don't currently support that distro."
-  exit;
+  exit 1;
 fi
 
 fancy_echo "Updating system packages ..."

--- a/mac
+++ b/mac
@@ -1,12 +1,18 @@
 #!/usr/bin/env zsh
+CLEAR="\033[0m"
+ORANGE="\033[33m"
 
 successfully() {
   $* || (echo "\nfailed" 1>&2 && exit 1)
 }
 
 fancy_echo() {
-  echo "\n$1"
+  echo -e ${ORANGE}$1${CLEAR}
+  echo
 }
+
+
+# Mac Specific
 
 if -f /etc/zshenv; then
   fancy_echo "Fix OSX zsh environment bug ..."
@@ -24,6 +30,16 @@ if ! grep -qs "recommended by brew doctor" ~/.zshrc; then
     successfully source ~/.zshrc
 fi
 
+fancy_echo "Install GNU Compiler Collection, a necessary prerequisite to installing Ruby ..."
+  successfully brew tap homebrew/dupes
+  successfully brew install apple-gcc42
+
+fancy_echo "Install reattach-to-user-namespace, for copy-paste and RubyMotion compatibility with tmux ..."
+  successfully brew install reattach-to-user-namespace
+
+
+# Cross platform
+
 fancy_echo "Install Postgres, a good open source relational database ..."
   successfully brew install postgres --no-python
   successfully initdb /usr/local/var/postgres -E utf8
@@ -39,9 +55,6 @@ fancy_echo "Install ctags, for indexing files for vim tab completion of methods,
 
 fancy_echo "Install tmux, for saving project state and switching between projects ..."
   successfully brew install tmux
-
-fancy_echo "Install reattach-to-user-namespace, for copy-paste and RubyMotion compatibility with tmux ..."
-  successfully brew install reattach-to-user-namespace
 
 fancy_echo "Install ImageMagick, for cropping and re-sizing images ..."
   successfully brew install imagemagick
@@ -69,10 +82,6 @@ fancy_echo "Install rbenv-gem-rehash so the shell automatically picks up binarie
 
 fancy_echo "Install ruby-build for installing Rubies ..."
   successfully brew install ruby-build
-
-fancy_echo "Install GNU Compiler Collection, a necessary prerequisite to installing Ruby ..."
-  successfully brew tap homebrew/dupes
-  successfully brew install apple-gcc42
 
 fancy_echo "Install Ruby 1.9.3-p392 ..."
   CC=gcc-4.2 successfully rbenv install 1.9.3-p392


### PR DESCRIPTION
- Remove things from linux that were removed from mac in 8ad09c3
- Keep fancy_echo lines the same on linux and mac, both for a consistent
  user experience, and for easier diffs
- Move platform-specific sections to top
- Update mac fancy_echo to match linux fancy_echo (fancy colors!)
- In linux-prerequisites, use exit code 1 if not supported

![Screenshot of diff between `linux` and `mac`](https://f.cloud.github.com/assets/552093/376148/44bd5164-a406-11e2-87f9-5c5e7ab112d5.png)
