### PR TITLE
Install lzma compression library for Ag

### DIFF
--- a/linux
+++ b/linux
@@ -44,7 +44,7 @@ fancy_echo "Installing Redis, a good key-value database ..."
 
 fancy_echo "Installing The Silver Searcher (better than ack or grep) to search the contents of files ..."
   successfully git clone git://github.com/ggreer/the_silver_searcher.git /tmp/the_silver_searcher
-  successfully sudo aptitude install -y automake pkg-config libpcre3-dev zlib1g-dev
+  successfully sudo aptitude install -y automake pkg-config libpcre3-dev zlib1g-dev liblzma-dev
   successfully sh /tmp/the_silver_searcher/build.sh
   successfully cd /tmp/the_silver_searcher
   successfully sh build.sh


### PR DESCRIPTION
Installs liblzma-dev which is required for _The Silver Searcher_ on Ubuntu 13.04 Raring.  Without this, installation fails with the following error:

```
checking for LZMA... no
configure: error: Package requirements (liblzma) were not met:

No package 'liblzma' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables LZMA_CFLAGS
and LZMA_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
failed
make: *** No rule to make target `install'.  Stop.
failed
```
