### PR TITLE
Remove .zshrc stub creation

### DIFF
--- a/linux
+++ b/linux
@@ -106,8 +106,3 @@ fancy_echo "Installing Heroku CLI client ..."
 
 fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
   successfully heroku plugins:install git://github.com/ddollar/heroku-config.git
-
-if ! grep -qs "DO NOT EDIT BELOW THIS LINE" ~/.zshrc; then
-  fancy_echo "Prepare ~/.zshrc for http://github.com/thoughtbot/dotfiles ..."
-  successfully echo "# DO NOT EDIT BELOW THIS LINE\n" >> ~/.zshrc
-fi

--- a/mac
+++ b/mac
@@ -96,8 +96,3 @@ fancy_echo "Installing Heroku CLI client ..."
 
 fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
   successfully heroku plugins:install git://github.com/ddollar/heroku-config.git
-
-if ! grep -qs "DO NOT EDIT BELOW THIS LINE" ~/.zshrc; then
-  fancy_echo "Prepare ~/.zshrc for http://github.com/thoughtbot/dotfiles ..."
-    successfully echo "# DO NOT EDIT BELOW THIS LINE\n" >> ~/.zshrc
-fi


### PR DESCRIPTION
Laptop currently generates a .zshrc file if one does not already exist.
However, this file is created with the # DO NOT EDIT BELOW THIS LINE
comment that does not fit with the new thoughtbot/dotfiles convention
of storing changes in .local files instead of above the placeholder
comment. If a user attempts to run laptop and then install dotfiles,
the dotfiles installation will not install .zshrc because of the
existing stub.

This change removes the creation of the .zshrc stub for both mac and
linux scripts.
