### PR TITLE
Remove duplicate Foreman install

### DIFF
--- a/linux
+++ b/linux
@@ -95,7 +95,7 @@ fancy_echo "Updating to latest Rubygems version ..."
   successfully gem update --system
 
 fancy_echo "Installing critical Ruby gems for Rails development ..."
-  successfully gem install bundler foreman pg rails unicorn --no-document
+  successfully gem install bundler pg rails unicorn --no-document
 
 fancy_echo "Installing GitHub CLI client ..."
   successfully curl http://hub.github.com/standalone -sLo ~/.bin/hub

--- a/mac
+++ b/mac
@@ -85,7 +85,7 @@ fancy_echo "Updating to latest Rubygems version ..."
   successfully gem update --system
 
 fancy_echo "Installing critical Ruby gems for Rails development ..."
-  successfully gem install bundler foreman pg rails unicorn --no-document
+  successfully gem install bundler pg rails unicorn --no-document
 
 fancy_echo "Installing GitHub CLI client ..."
   successfully curl http://hub.github.com/standalone -sLo ~/.bin/hub


### PR DESCRIPTION
Heroku Toobelt includes Foreman. Installing the gem in addition to Toolbelt
may cause future problems. For example, the Toolbelt is auto-updating and the
gem isn't. So, we might run into weird problems with an out-of-sync foreman
vs Heroku command-line tool.

Thanks, @jonmountjoy.
