### PR TITLE
Load Ruby 2 `gem` command before installing gems

### DIFF
--- a/linux
+++ b/linux
@@ -90,6 +90,7 @@ fancy_echo "Installing Ruby 2.0.0-p247 ..."
 fancy_echo "Setting Ruby 2.0.0-p247 as global default Ruby ..."
   successfully rbenv global 2.0.0-p247
   successfully rbenv shell 2.0.0-p247
+  successfully rbenv rehash
 
 fancy_echo "Updating to latest Rubygems version ..."
   successfully gem update --system

--- a/mac
+++ b/mac
@@ -83,6 +83,7 @@ fancy_echo "Installing Ruby 2.0.0-p247 ..."
 fancy_echo "Setting Ruby 2.0.0-p247 as global default Ruby ..."
   successfully rbenv global 2.0.0-p247
   successfully rbenv shell 2.0.0-p247
+  successfully rbenv rehash
 
 fancy_echo "Updating to latest Rubygems version ..."
   successfully gem update --system


### PR DESCRIPTION
Fixes these issues:

https://github.com/thoughtbot/laptop/issues/98
https://github.com/thoughtbot/laptop/issues/119
https://github.com/thoughtbot/laptop/issues/117
