### PR TITLE
lsb_release -> /etc/os-release for distro detection

### DIFF
--- a/linux
+++ b/linux
@@ -11,7 +11,7 @@ fancy_echo() {
   echo
 }
 
-if lsb_release -c | grep -qEv 'precise|quantal|wheezy|raring|jessie'
+if ! grep -qiE 'precise|quantal|wheezy|raring|jessie' /etc/os-release
 then
   fancy_echo "Sorry! we don't currently support that distro."
   exit 1;

--- a/linux-prerequisites
+++ b/linux-prerequisites
@@ -11,10 +11,10 @@ fancy_echo() {
   echo
 }
 
-if lsb_release -c | grep -qEv 'precise|quantal|wheezy|raring|jessie'
+if ! grep -qiE 'precise|quantal|wheezy|raring|jessie' /etc/os-release
 then
   fancy_echo "Sorry! we don't currently support that distro."
-  exit;
+  exit 1;
 fi
 
 fancy_echo "Updating system packages ..."


### PR DESCRIPTION
This uses the freedesktop os-release standard to figure out which distro 
we're on, which should make it easier and more reliable if/when we support
other distros.

Details: http://www.freedesktop.org/software/systemd/man/os-release.html

RE: #121
