### PR TITLE
Change echo to printf in common-components

### DIFF
--- a/common-components/shared-functions
+++ b/common-components/shared-functions
@@ -1,3 +1,3 @@
 fancy_echo() {
-  echo "\n$1"
+  printf "\n%b\n" "$1"
 }

--- a/linux
+++ b/linux
@@ -24,7 +24,7 @@ fi
 ### end common-components/check-home-bin
 
 fancy_echo() {
-  echo "\n$1"
+  printf "\n%b\n" "$1"
 }
 ### end common-components/shared-functions
 

--- a/linux-prerequisites
+++ b/linux-prerequisites
@@ -14,7 +14,7 @@ set -e
 ### end common-components/exit-trap
 
 fancy_echo() {
-  echo "\n$1"
+  printf "\n%b\n" "$1"
 }
 ### end common-components/shared-functions
 

--- a/mac
+++ b/mac
@@ -24,7 +24,7 @@ fi
 ### end common-components/check-home-bin
 
 fancy_echo() {
-  echo "\n$1"
+  printf "\n%b\n" "$1"
 }
 ### end common-components/shared-functions
 


### PR DESCRIPTION
Make the `fancy_echo()` function more portable.

According to the POSIX standard `echo` has an unspecified behavior if using "\" in any of the arguments. 

Came up for me using `linux-prerequisites` on a new Ubuntu box—whatever version of Bash it was using (before doing the `chsh zsh`-thing) just printed, literally, `\n[whatever]` to the screen wherever `fancy_echo` was being used.

To correct this use printf. 

References:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html#tag_20_37_16
http://wiki.bash-hackers.org/scripting/nonportable#echo_command
