### PR TITLE
Do not rehash on rbenv initialization

### DIFF
--- a/linux
+++ b/linux
@@ -93,7 +93,7 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
   if ! grep -qs "rbenv init" ~/.zshrc; then
     echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.zshrc
 
-    echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+    echo 'eval "$(rbenv init - --no-rehash)"' >> ~/.zshrc
   fi
 
   source ~/.zshrc

--- a/linux-components/rbenv
+++ b/linux-components/rbenv
@@ -4,7 +4,7 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
   if ! grep -qs "rbenv init" ~/.zshrc; then
     echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.zshrc
 
-    echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+    echo 'eval "$(rbenv init - --no-rehash)"' >> ~/.zshrc
   fi
 
   source ~/.zshrc

--- a/mac
+++ b/mac
@@ -83,7 +83,7 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
   brew install rbenv
 
   if ! grep -qs "rbenv init" ~/.zshrc; then
-    echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+    echo 'eval "$(rbenv init - --no-rehash)"' >> ~/.zshrc
 
     fancy_echo "Enable shims and autocompletion ..."
       eval "$(rbenv init -)"

--- a/mac-components/rbenv
+++ b/mac-components/rbenv
@@ -2,7 +2,7 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
   brew install rbenv
 
   if ! grep -qs "rbenv init" ~/.zshrc; then
-    echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+    echo 'eval "$(rbenv init - --no-rehash)"' >> ~/.zshrc
 
     fancy_echo "Enable shims and autocompletion ..."
       eval "$(rbenv init -)"


### PR DESCRIPTION
We install rbenv-gem-rehash, which will automatically rehash when you install
new binaries, so I can't conceive of why this is necessary. I've been using
--no-rehash for months now without issue, and there's a noticeable speed up in
shell initialization.
