### PR TITLE
Add C compiler installation instructions for 10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Requirements
 
 1) Install a C compiler.
 
-Use [OS X GCC Installer](https://github.com/kennethreitz/osx-gcc-installer/) for
-Snow Leopard (OS X 10.6).
+For Snow Leopard (10.6): use [OS X GCC Installer](https://github.com/kennethreitz/osx-gcc-installer/)
 
-Use [Command Line Tools for XCode](https://developer.apple.com/downloads/index.action)
-for Lion (OS X 10.7) or Mountain Lion (OS X 10.8).
+For Lion (10.7) or Mountain Lion (10.8): use [Command Line Tools for XCode](https://developer.apple.com/downloads/index.action)
+
+For Mavericks (10.9): run `xcode-select --install` in your terminal and then click "Install".
 
 2) Set zsh as your login shell:
 


### PR DESCRIPTION
Reformat C compiler instructions for various OS X versions so people can scan by
their version of OS X.
