### PR TITLE
Configure Bundler for parallel gem installs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ rendered `linux`, `linux-preqrequisites`, or `mac` files. `git diff` is your
 friend - check the output. If it looks as expected, commit the rendered
 installation files.
 
-4) A reminder: be extra sure to render the installation files before issuing a pull request.
+4) A reminder: be extra sure to render the installation files before issuing a
+pull request.
 
 Supporting additional distros or operating systems
 ==================================================

--- a/Manifest.linux
+++ b/Manifest.linux
@@ -9,4 +9,5 @@ linux-components/debian-derivative-packages
 linux-components/silver-searcher-from-source
 linux-components/rbenv
 common-components/ruby-environment
+linux-components/bundler
 linux-components/heroku

--- a/Manifest.mac
+++ b/Manifest.mac
@@ -9,4 +9,5 @@ mac-components/packages
 mac-components/rbenv
 mac-components/compiler-and-libraries
 common-components/ruby-environment
+mac-components/bundler
 mac-components/heroku

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ What it sets up
 * Homebrew for managing operating system libraries (OS X only)
 * ImageMagick for cropping and resizing images
 * Postgres for storing relational data
-* Postgres gem for talking to Postgres from Ruby
 * Qt for headless JavaScript testing via Capybara Webkit
 * Rails gem for writing web applications
 * Rbenv for managing versions of the Ruby programming language

--- a/common-components/ruby-environment
+++ b/common-components/ruby-environment
@@ -8,8 +8,11 @@ fancy_echo "Setting Ruby 2.0.0-p353 as global default Ruby ..."
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
 
-fancy_echo "Installing critical Ruby gems for Rails development ..."
-  gem install bundler pg rails unicorn --no-document
+fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
+  gem install bundler --no-document --pre
+
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document
 
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub

--- a/linux
+++ b/linux
@@ -115,13 +115,21 @@ fancy_echo "Setting Ruby 2.0.0-p353 as global default Ruby ..."
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
 
-fancy_echo "Installing critical Ruby gems for Rails development ..."
-  gem install bundler pg rails unicorn --no-document
+fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
+  gem install bundler --no-document --pre
+
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document
 
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub
   chmod +x ~/.bin/hub
 ### end common-components/ruby-environment
+
+fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
+  number_of_cores=`nproc`
+  bundle config --global jobs `expr $number_of_cores - 1`
+### end linux-components/bundler
 
 fancy_echo "Installing Heroku CLI client ..."
   wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh

--- a/linux-components/bundler
+++ b/linux-components/bundler
@@ -1,0 +1,3 @@
+fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
+  number_of_cores=`nproc`
+  bundle config --global jobs `expr $number_of_cores - 1`

--- a/mac
+++ b/mac
@@ -121,13 +121,21 @@ fancy_echo "Setting Ruby 2.0.0-p353 as global default Ruby ..."
 fancy_echo "Updating to latest Rubygems version ..."
   gem update --system
 
-fancy_echo "Installing critical Ruby gems for Rails development ..."
-  gem install bundler pg rails unicorn --no-document
+fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
+  gem install bundler --no-document --pre
+
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document
 
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub
   chmod +x ~/.bin/hub
 ### end common-components/ruby-environment
+
+fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
+  number_of_cores=`sysctl -n hw.ncpu`
+  bundle config --global jobs `expr $number_of_cores - 1`
+### end mac-components/bundler
 
 fancy_echo "Installing Heroku CLI client ..."
   brew install heroku-toolbelt

--- a/mac-components/bundler
+++ b/mac-components/bundler
@@ -1,0 +1,3 @@
+fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
+  number_of_cores=`sysctl -n hw.ncpu`
+  bundle config --global jobs `expr $number_of_cores - 1`


### PR DESCRIPTION
- Set it globally for OS X.
- Determine number of cores dynamically.
- Pick one number less than number of cores to avoid deadlock errors.
