### PR TITLE
Use Ruby 2.0.0.p353 as deafult

### DIFF
--- a/common-components/ruby-environment
+++ b/common-components/ruby-environment
@@ -1,8 +1,8 @@
-fancy_echo "Installing Ruby 2.0.0-p247 ..."
-  rbenv install 2.0.0-p247
+fancy_echo "Installing Ruby 2.0.0-p353 ..."
+  rbenv install 2.0.0-p353
 
-fancy_echo "Setting Ruby 2.0.0-p247 as global default Ruby ..."
-  rbenv global 2.0.0-p247
+fancy_echo "Setting Ruby 2.0.0-p353 as global default Ruby ..."
+  rbenv global 2.0.0-p353
   rbenv rehash
 
 fancy_echo "Updating to latest Rubygems version ..."


### PR DESCRIPTION
Resolves reported vulnerability in Ruby 2.0.0-p247:

https://www.ruby-lang.org/en/news/2013/11/22/heap-overflow-in-floating-point-parsing-cve-2013-4164/
