### PR TITLE
Fix "Could not verify the SSL certificate" errors

### DIFF
--- a/mac-components/compiler-and-libraries
+++ b/mac-components/compiler-and-libraries
@@ -4,5 +4,7 @@ fancy_echo "Installing GNU Compiler Collection, a necessary prerequisite to inst
 
 fancy_echo "Upgrading and linking OpenSSL ..."
   brew install openssl
+  brew link openssl --force
+  brew install curl-ca-bundle
 
 export CC=gcc-4.2


### PR DESCRIPTION
The error message indicates the connection failed because OpenSSL was unable
to verify the server certificate. The SSL certificates that comes with Mac OS
X 10.8 may be outdated.

http://bit.ly/ruby-ssl
