### PR TITLE
Add command for accepting XCode agreement on Mavericks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For Snow Leopard (10.6): use [OS X GCC Installer](https://github.com/kennethreit
 
 For Lion (10.7) or Mountain Lion (10.8): use [Command Line Tools for XCode](https://developer.apple.com/downloads/index.action)
 
-For Mavericks (10.9): run `xcode-select --install` in your terminal and then click "Install".
+For Mavericks (10.9): run `sudo xcodebuild -license` and follow the instructions to accept the XCode agreement.  Then run `xcode-select --install` in your terminal and then click "Install".
 
 2) Set zsh as your login shell:
 


### PR DESCRIPTION
On Mavericks, I followed the instructions for my completely brand new MacBook Air, but ran into the following:

```
Chips-MacBook-Air% zsh <(curl -s https://raw.github.com/thoughtbot/laptop/master/mac)

Fixing OSX zsh environment bug ...

WARNING: Improper use of the sudo command could lead to data loss
or the deletion of important system files. Please double-check your
typing when using sudo. Type "man sudo" for more information.

To proceed, enter your password, or type Ctrl-C to abort.

Password:

Installing Homebrew, a good OS X package manager ...
==> This script will install:
/usr/local/bin/brew
/usr/local/Library/...
/usr/local/share/man/man1/brew.1

Press ENTER to continue or any other key to abort
==> /usr/bin/sudo /bin/mkdir /usr/local
==> /usr/bin/sudo /bin/chmod g+rwx /usr/local
==> /usr/bin/sudo /usr/bin/chgrp admin /usr/local
==> Downloading and installing Homebrew...


Agreeing to the Xcode/iOS license requires admin privileges, please re-run as root via sudo.


==> Installation successful!
You should run `brew doctor' *before* you install anything.
Now type: brew help


Agreeing to the Xcode/iOS license requires admin privileges, please re-run as root via sudo.


Error: Failure while executing: git init 
failed

```

Running `sudo xcodebuild -license` fixed the issue, so I updated the README to reflect this issue since it might help others. 
