### PR TITLE
Change Homebrew install path

### DIFF
--- a/mac
+++ b/mac
@@ -36,7 +36,7 @@ fi
 
 if (( ! $+commands[brew] )); then
   fancy_echo "Installing Homebrew, a good OS X package manager ..."
-    ruby <(curl -fsS https://raw.github.com/mxcl/homebrew/go/install)
+    ruby <(curl -fsS https://raw.github.com/Homebrew/homebrew/go/install)
     brew update
 
   if ! grep -qs "recommended by brew doctor" ~/.zshrc; then


### PR DESCRIPTION
Looks like it's hosted in a different repository now. The previous path redirects to this one.
