### PR TITLE
Use thoughtbot/rcm for Homebrew

### DIFF
--- a/mac
+++ b/mac
@@ -145,7 +145,7 @@ fancy_echo "Installing the heroku-config plugin to pull config variables locally
 ### end mac-components/heroku
 
 fancy_echo "Installing rcm, to manage your dotfiles ..."
-  brew tap mike-burns/rcm
+  brew tap thoughtbot/rcm
   brew install rcm
 ### end mac-components/rcm
 

--- a/mac-components/rcm
+++ b/mac-components/rcm
@@ -1,3 +1,3 @@
 fancy_echo "Installing rcm, to manage your dotfiles ..."
-  brew tap mike-burns/rcm
+  brew tap thoughtbot/rcm
   brew install rcm


### PR DESCRIPTION
Back when rcm was an experiment by Mike Burns, the `homebrew-rcm` GitHub
repo was hosted under the `mike-burns` account. It has since been moved
to `thoughtbot` so that more may share in the love.
