### PR TITLE
Install gems after configuring bundler for parallel installation.

### DIFF
--- a/Manifest.linux
+++ b/Manifest.linux
@@ -10,5 +10,6 @@ linux-components/silver-searcher-from-source
 linux-components/rbenv
 common-components/ruby-environment
 linux-components/bundler
+common-components/default-gems
 linux-components/heroku
 linux-components/rcm

--- a/Manifest.mac
+++ b/Manifest.mac
@@ -10,5 +10,6 @@ mac-components/rbenv
 mac-components/compiler-and-libraries
 common-components/ruby-environment
 mac-components/bundler
+common-components/default-gems
 mac-components/heroku
 mac-components/rcm

--- a/common-components/default-gems
+++ b/common-components/default-gems
@@ -1,0 +1,2 @@
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document

--- a/common-components/ruby-environment
+++ b/common-components/ruby-environment
@@ -13,9 +13,6 @@ fancy_echo "Updating to latest Rubygems version ..."
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
 
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
-
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub
   chmod +x ~/.bin/hub

--- a/linux
+++ b/linux
@@ -120,9 +120,6 @@ fancy_echo "Updating to latest Rubygems version ..."
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
 
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
-
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub
   chmod +x ~/.bin/hub
@@ -132,6 +129,10 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   number_of_cores=`nproc`
   bundle config --global jobs `expr $number_of_cores - 1`
 ### end linux-components/bundler
+
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document
+### end common-components/default-gems
 
 fancy_echo "Installing Heroku CLI client ..."
   wget -qO- https://toolbelt.heroku.com/install-ubuntu.sh | sh

--- a/mac
+++ b/mac
@@ -125,9 +125,6 @@ fancy_echo "Updating to latest Rubygems version ..."
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
 
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
-
 fancy_echo "Installing GitHub CLI client ..."
   curl http://hub.github.com/standalone -sLo ~/.bin/hub
   chmod +x ~/.bin/hub
@@ -137,6 +134,10 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   number_of_cores=`sysctl -n hw.ncpu`
   bundle config --global jobs `expr $number_of_cores - 1`
 ### end mac-components/bundler
+
+fancy_echo "Installing Rails ..."
+  gem install rails --no-document
+### end common-components/default-gems
 
 fancy_echo "Installing Heroku CLI client ..."
   brew install heroku-toolbelt


### PR DESCRIPTION
Move the installation of rails gem (+ dependencies) to run **after** bundler is configured for parallel downloads. This makes the initial install hopefully a lot faster.
