### PR TITLE
change thoughtbot/rcm to thoughtbot/formulae

### DIFF
--- a/mac-components/rcm
+++ b/mac-components/rcm
@@ -1,3 +1,3 @@
 fancy_echo "Installing rcm, to manage your dotfiles ..."
-  brew tap thoughtbot/rcm
+  brew tap thoughtbot/formulae
   brew install rcm


### PR DESCRIPTION
Started reading the thoughtbot playbook last week, which led me to laptop. Calling mac from Terminal went fine untill the last installation which yielded "ERROR: no available formula for rcm". Googling the error message brought me to Matthew Sumner's commit # 2915cf1f696777a7438d0bbf92f688f32e1e8264 in the dotfile repo. Applying the same modif to the laptop mac shell script got rid of the error message. If you accept my pull-in request, that'd be my first ofishal contribution to the open source world.
