### PR TITLE
Install Suspenders instead of Rails

### DIFF
--- a/common-components/default-gems
+++ b/common-components/default-gems
@@ -1,2 +1,2 @@
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
+fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
+  gem install suspenders --no-document

--- a/linux
+++ b/linux
@@ -159,8 +159,8 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   bundle config --global jobs $((number_of_cores - 1))
 ### end linux-components/bundler
 
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
+fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
+  gem install suspenders --no-document
 ### end common-components/default-gems
 
 fancy_echo "Installing Heroku CLI client ..."

--- a/mac
+++ b/mac
@@ -146,8 +146,8 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   bundle config --global jobs $((number_of_cores - 1))
 ### end mac-components/bundler
 
-fancy_echo "Installing Rails ..."
-  gem install rails --no-document
+fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
+  gem install suspenders --no-document
 ### end common-components/default-gems
 
 fancy_echo "Installing Heroku CLI client ..."


### PR DESCRIPTION
We more typically create Rails apps using Suspenders. Rails is a dependency of
Suspenders, so it will still be installed.
