### PR TITLE
Use Homebrew for `hub` on OS X

### DIFF
--- a/Manifest.linux
+++ b/Manifest.linux
@@ -13,4 +13,5 @@ common-components/ruby-environment
 linux-components/bundler
 common-components/default-gems
 linux-components/heroku
+linux-components/github
 linux-components/rcm

--- a/Manifest.mac
+++ b/Manifest.mac
@@ -13,4 +13,5 @@ common-components/ruby-environment
 mac-components/bundler
 common-components/default-gems
 mac-components/heroku
+mac-components/github
 mac-components/rcm

--- a/common-components/ruby-environment
+++ b/common-components/ruby-environment
@@ -12,7 +12,3 @@ fancy_echo "Updating to latest Rubygems version ..."
 
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
-
-fancy_echo "Installing GitHub CLI client ..."
-  curl http://hub.github.com/standalone -sLo ~/.bin/hub
-  chmod +x ~/.bin/hub

--- a/linux
+++ b/linux
@@ -147,10 +147,6 @@ fancy_echo "Updating to latest Rubygems version ..."
 
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
-
-fancy_echo "Installing GitHub CLI client ..."
-  curl http://hub.github.com/standalone -sLo ~/.bin/hub
-  chmod +x ~/.bin/hub
 ### end common-components/ruby-environment
 
 fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
@@ -168,6 +164,11 @@ fancy_echo "Installing Heroku CLI client ..."
 fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
   heroku plugins:install git://github.com/ddollar/heroku-config.git
 ### end linux-components/heroku
+
+fancy_echo "Installing GitHub CLI client ..."
+  curl http://hub.github.com/standalone -sLo ~/.bin/hub
+  chmod +x ~/.bin/hub
+### end linux-components/github
 
 fancy_echo "Installing rcm, to manage your dotfiles ..."
   wget -O /tmp/rcm_1.1.0_all.deb http://mike-burns.com/project/rcm/rcm_1.1.0_all.deb

--- a/linux-components/github
+++ b/linux-components/github
@@ -1,0 +1,3 @@
+fancy_echo "Installing GitHub CLI client ..."
+  curl http://hub.github.com/standalone -sLo ~/.bin/hub
+  chmod +x ~/.bin/hub

--- a/mac
+++ b/mac
@@ -135,10 +135,6 @@ fancy_echo "Updating to latest Rubygems version ..."
 
 fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
   gem install bundler --no-document --pre
-
-fancy_echo "Installing GitHub CLI client ..."
-  curl http://hub.github.com/standalone -sLo ~/.bin/hub
-  chmod +x ~/.bin/hub
 ### end common-components/ruby-environment
 
 fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
@@ -156,6 +152,10 @@ fancy_echo "Installing Heroku CLI client ..."
 fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
   heroku plugins:install git://github.com/ddollar/heroku-config.git
 ### end mac-components/heroku
+
+fancy_echo "Installing GitHub CLI client ..."
+  brew install hub
+### end mac-components/github
 
 fancy_echo "Installing rcm, to manage your dotfiles ..."
   brew tap thoughtbot/formulae

--- a/mac-components/github
+++ b/mac-components/github
@@ -1,0 +1,2 @@
+fancy_echo "Installing GitHub CLI client ..."
+  brew install hub


### PR DESCRIPTION
The previous method places the `hub` command in ~/bin/hub, which shows up in
the dotfiles repo for thoughtbot/dotfiles users. We could gitignore the
`bin/hub` gem there, but the hub README recommends using Homebrew or a package
manager when it is available.

This leaves the Linux version functionally the same.
