### PR TITLE
Install Node.js on Mac laptops

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ What it sets up
 * Hub gem for interacting with the GitHub API
 * Homebrew for managing operating system libraries (OS X only)
 * ImageMagick for cropping and resizing images
+* Node.js and NPM, for running apps and installing JavaScript packages
 * Postgres for storing relational data
 * Qt for headless JavaScript testing via Capybara Webkit
 * Rails gem for writing web applications

--- a/mac
+++ b/mac
@@ -89,6 +89,21 @@ fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integ
 
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   brew install watch
+
+node_version = "0.10.28"
+
+if ! command -v nvm &>/dev/null; then
+  fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing JavaScript packages ..."
+    brew install nvm
+    printf 'export PATH="$PATH:/usr/local/lib/node_modules"\n' >> ~/.zshrc
+    printf 'source $(brew --prefix nvm)/nvm.sh\n' >> ~/.zshrc
+
+    source ~/.zshrc
+    nvm install $node_version
+    printf "nvm use \"$node_version\" > /dev/null\n" >> ~/.zshrc
+else
+  fancy_echo "NVM already installed. Skipping ..."
+fi
 ### end mac-components/packages
 
 fancy_echo "Starting Postgres ..."

--- a/mac-components/packages
+++ b/mac-components/packages
@@ -27,3 +27,18 @@ fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integ
 
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   brew install watch
+
+node_version = "0.10.28"
+
+if ! command -v nvm &>/dev/null; then
+  fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing JavaScript packages ..."
+    brew install nvm
+    printf 'export PATH="$PATH:/usr/local/lib/node_modules"\n' >> ~/.zshrc
+    printf 'source $(brew --prefix nvm)/nvm.sh\n' >> ~/.zshrc
+
+    source ~/.zshrc
+    nvm install $node_version
+    printf "nvm use \"$node_version\" > /dev/null\n" >> ~/.zshrc
+else
+  fancy_echo "NVM already installed. Skipping ..."
+fi


### PR DESCRIPTION
I think most of us have Node.js on our machines. Some common reasons to
install it include:
- Installing CoffeeScript, Bower, and other JavaScript packages.
- Developing on Ralph, our Hubot instance, which runs Express.js.
