### PR TITLE
Use command -v to test command existence

### DIFF
--- a/linux
+++ b/linux
@@ -96,7 +96,7 @@ fancy_echo "Changing your shell to zsh ..."
   chsh -s $(which zsh)
 ### end common-components/zsh
 
-if ! which ag &>/dev/null; then
+if ! command -v ag &>/dev/null; then
   fancy_echo "Installing The Silver Searcher (better than ack or grep) to search the contents of files ..."
     git clone git://github.com/ggreer/the_silver_searcher.git /tmp/the_silver_searcher
     sudo aptitude install -y automake pkg-config libpcre3-dev zlib1g-dev liblzma-dev

--- a/linux-components/silver-searcher-from-source
+++ b/linux-components/silver-searcher-from-source
@@ -1,4 +1,4 @@
-if ! which ag &>/dev/null; then
+if ! command -v ag &>/dev/null; then
   fancy_echo "Installing The Silver Searcher (better than ack or grep) to search the contents of files ..."
     git clone git://github.com/ggreer/the_silver_searcher.git /tmp/the_silver_searcher
     sudo aptitude install -y automake pkg-config libpcre3-dev zlib1g-dev liblzma-dev


### PR DESCRIPTION
Use preferred POSIX `command -v` test for command existence instead of
previous `which` technique. `which` exits with status `1` if nothing is found.
That would cause the script to abort because we use `set -e`.

http://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script
