### PR TITLE
Automatically create laptopped vagrant boxes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 .vagrant
 Vagrantfile
+*.box
+test/succeeded*

--- a/README.md
+++ b/README.md
@@ -85,6 +85,36 @@ Put your customizations in `~/.laptop.local`. For example, your
     brew cask install google-chrome
     brew cask install rdio
 
+Laptopped linux vagrant boxes
+-----------------------------------------------------------
+
+We now publish [vagrant](http://vagrantup.com) boxes for every supported linux
+distro. These boxes have the laptop script applied already and are ready to go.
+Getting started is as easy as creating a Vagrantfile that looks like:
+
+    Vagrant.configure('2') do
+      config.vm.box = 'thoughtbot/ubuntu-14-04-server-with-laptop'
+    end
+
+
+```sh
+# And then in the same directory as your Vagrantfile . . .
+vagrant up
+vagrant ssh
+
+```
+
+Laptopped vagrantcloud boxes currently available:
+
+* `thoughtbot/debian-wheezy-64-with-laptop`
+* `thoughtbot/debian-jessie-64-with-laptop`
+* `thoughtbot/ubuntu-14-04-server-with-laptop`
+* `thoughtbot/ubuntu-13-10-server-with-laptop`
+* `thoughtbot/ubuntu-12-04-server-with-laptop`
+
+See our [vagrantcloud profile](https://vagrantcloud.com/thoughtbot). You must
+have vagrant >= 1.5.0 to use vagrantcloud images directly.
+
 Credits
 -------
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,10 +9,15 @@ information about OSX testing.
 ## Prerequisites
 
 1. [VirtualBox][]
-2. [Vagrant][]
+2. [Vagrant][] - version >= 1.5.0
+3. [aws-cli][] - optional, for publishers only.
 
 [VirtualBox]: https://www.virtualbox.org/
 [Vagrant]: http://www.vagrantup.com/
+[aws-cli]: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html
+
+`aws-cli` is only necessary if you're one of the maintainers and want to
+publish new "laptopped" boxes.
 
 ## Running the tests
 
@@ -41,7 +46,7 @@ You can test idempotency (allowing you to run the script multiple times in the
 same environment) by exporting `KEEP_VM` before running `./test/runner.sh`
 thusly:
 
-  KEEP_VM=1 ./test/runner.sh
+    KEEP_VM=1 ./test/runner.sh
 
 ## OSX Testing
 
@@ -57,16 +62,90 @@ OSX will need to be handled specially:
 
 [VMware]: http://www.vmware.com/
 
-## Notes on creating vagrant base boxes
+## Publishing
+
+First, you'll need to install and configure [aws-cli].  When you're ready to
+publish a new set of boxes, run thusly:
+
+    PACKAGE_BOXES=1 ./test/runner.sh
+
+This will package all successfully tested boxes.  You do not need to re-create
+or update the box config in vagrantcloud for an updated box, as long as the URL
+stays the same.
+
+Run:
+
+    ./test/publish_laptopped_boxes.sh
+
+to actually publish the boxes to s3 after you've packaged the boxes above. This
+will copy the new box to a temporary name, remove the original and move the
+temp into place to minimize downtime.
+
+## Removing a deprecated release
+
+- Remove the vagrantfile under `test/`
+- Remove the files published to s3
+- Remove the box config in vagrantcloud
+- Update README.md
+
+## Creating new base boxes to test a new release
+
+1. Download a 64 bit minimal server ISO
+1. Set up a new virtualbox machine
+    - Name it logically: `ubuntu-14-04-server` or similar
+    - 512 meg of RAM
+    - 2 CPUs
+    - 8 gig dynamically allocated disk, choosing the default VDI storage
+1. Install. During installation:
+    - Create a `vagrant` user with the password "vagrant"
+    - Don't encrypt your home drive
+    - Choose the minimal packages necessary to get a working SSH server
+1. Reboot. And then follow the [general base box instructions][], specifically:
+    - Log in as the `vagrant` user, `sudo -i` and then set root's password to 'vagrant'
+    - Modify `/etc/sudoers` to allow vagrant password-less `sudo` for all commands
+    - Install the vagrant insecure SSH keypair into the `vagrant` account
+    - Set up guest additions according to the [virtualbox provider docs][]. See [this bug in 4.3.10][].
+    - Update and clean up: `aptitude update && aptitude dist-upgrade -y && aptitude clean`
+1. Package the new minimal base box.
+    `vagrant package --base ubuntu-14-04-server --output ubuntu-14-04-server.box`
+1. Test the new base box.
+    - Add the box to your local vagrant: `vagrant box add ubuntu-14-04-server.box --name ubuntu-14-04-server`
+    - Create a minimal `Vagrantfile` that uses your new box by name
+    - `vagrant up`
+    - Connect to your box via `vagrant ssh`
+    - Make sure you can see shared files under the `/vagrant` directory.
+    - If it works, clean up after yourself:
+    - `vagrant destroy`
+    - `vagrant box remove ubuntu-14-04-server`
+    - Remove the release ISO if you're sure everything works.
+1. Upload the new base box to s3. Assuming you have aws-cli installed:
+    `aws s3 cp ubuntu-14-04-server.box s3://laptop-boxes/ --acl public-read`
+1. Add a new box config to vagrantcloud, named and described logically.
+    - Create a version (0.1.0) and a provider with the s3 URL you created above.
+    - Release the config. It's OK if the box hasn't been uploaded to s3 yet,
+      vagrantcloud issues a 302 when a box is requested.
+1. Create a Vagrantfile under `test/` that uses the vagrantcloud remote name.
+1. Run `PACKAGE_BOXES=1 test/runner.sh` and see if laptop applied successfully.
+1. If tests completed successfully, you'll have a `*-with-laptop.box` file.
+    Publish it via `./test/publish_laptopped_boxes.sh`.
+1. Create another vagrantcloud box config, this time linking to the
+    `-with-laptop.box` image you uploaded to s3.
+
+[general base box instructions]:http://docs.vagrantup.com/v2/boxes/base.html
+[virtualbox provider docs]:http://docs.vagrantup.com/v2/virtualbox/boxes.html
+[this bug in 4.3.10]:https://github.com/dotless-de/vagrant-vbguest/issues/117
+
+## chsh errors
 
 The test script may fail when changing the vagrant user's shell to `zsh`. If
 this happens, you need to configure PAM to allow a user to change their shell
 without a password. Open '/etc/pam.d/chsh' and change the line:
 
-  auth		sufficient	pam_rootok.so
+    auth		sufficient	pam_rootok.so
 
 to
 
-  auth		sufficient	pam_permit.so
+    auth		sufficient	pam_permit.so
 
 which will allow the vagrant user to change their shell without a password.
+You'll need to repackage and re-upload the base box with this change.

--- a/test/Vagrantfile.13.10
+++ b/test/Vagrantfile.13.10
@@ -1,7 +1,0 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-Vagrant.configure('2') do |config|
-  box_name = "ubuntu-13-10"
-  config.vm.box = box_name
-  config.vm.box_url = "https://laptop-boxes.s3.amazonaws.com/#{box_name}.box"
-end

--- a/test/Vagrantfile.debian-jessie-64
+++ b/test/Vagrantfile.debian-jessie-64
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  name = 'debian-jessie-64'
+  config.vm.box = "thoughtbot/#{name}"
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.name = "laptop-#{name}"
+  end
+end

--- a/test/Vagrantfile.debian-wheezy-64
+++ b/test/Vagrantfile.debian-wheezy-64
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  name = 'debian-wheezy-64'
+  config.vm.box = "thoughtbot/#{name}"
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.name = "laptop-#{name}"
+  end
+end

--- a/test/Vagrantfile.jessie
+++ b/test/Vagrantfile.jessie
@@ -1,7 +1,0 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-Vagrant.configure('2') do |config|
-  box_name = "jessie64"
-  config.vm.box = box_name
-  config.vm.box_url = "https://laptop-boxes.s3.amazonaws.com/#{box_name}.box"
-end

--- a/test/Vagrantfile.precise
+++ b/test/Vagrantfile.precise
@@ -1,7 +1,0 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-Vagrant.configure('2') do |config|
-  box_name = "precise32-desktop"
-  config.vm.box = box_name
-  config.vm.box_url = "https://laptop-boxes.s3.amazonaws.com/#{box_name}.box"
-end

--- a/test/Vagrantfile.ubuntu-12-04-server
+++ b/test/Vagrantfile.ubuntu-12-04-server
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  name = 'ubuntu-12-04-server'
+  config.vm.box = "thoughtbot/#{name}"
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.name = "laptop-#{name}"
+  end
+end

--- a/test/Vagrantfile.ubuntu-13-10-server
+++ b/test/Vagrantfile.ubuntu-13-10-server
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  name = 'ubuntu-13-10-server'
+  config.vm.box = "thoughtbot/#{name}"
+  config.vm.provider :virtualbox do |virtualbox|
+    virtualbox.name = "laptop-#{name}"
+  end
+end

--- a/test/Vagrantfile.wheezy
+++ b/test/Vagrantfile.wheezy
@@ -1,7 +1,0 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-Vagrant.configure('2') do |config|
-  box_name = "wheezy64"
-  config.vm.box = box_name
-  config.vm.box_url = "https://laptop-boxes.s3.amazonaws.com/#{box_name}.box"
-end

--- a/test/common
+++ b/test/common
@@ -1,0 +1,41 @@
+message() {
+  printf "\e[1;34m:: \e[1;37m%s\e[0m\n" "$*"
+}
+
+failure_message() {
+  printf "\n\e[1;31mFAILURE\e[0m: \e[1;37m%s\e[0m\n\n" "$*" >&2;
+}
+
+failure() {
+  FAILED=true
+  failure_message
+  continue
+}
+
+set_box_names() {
+  LAPTOP_BASENAME="$(echo "$vagrantfile" | cut -d'.' -f2-)";
+  VIRTUALBOX_NAME="laptop-$LAPTOP_BASENAME";
+  BOX_NAME="$LAPTOP_BASENAME-with-laptop.box"
+}
+
+create_test_success_tracker(){
+  touch "./test/succeeded.$LAPTOP_BASENAME"
+}
+
+package_box() {
+  set_box_names
+
+  rm -f "$BOX_NAME"
+
+  message "Creating $BOX_NAME from $VIRTUALBOX_NAME"
+  vagrant package --base "$VIRTUALBOX_NAME" --output "$BOX_NAME"
+  message "Done creating $BOX_NAME"
+  create_test_success_tracker
+}
+
+check_for_aws() {
+  if ! command -v aws &>/dev/null; then
+    failure_message 'You must install aws-cli to publish boxes'
+    exit 1
+  fi
+}

--- a/test/publish_laptopped_boxes.sh
+++ b/test/publish_laptopped_boxes.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+source ./test/common
+
+upload_box_to_temp_location(){
+  message "Uploading box to s3: $BOX_NAME"
+  aws s3 cp "$BOX_NAME" "s3://laptop-boxes/$BOX_NAME.tmp" --acl public-read
+}
+
+move_box_into_place(){
+  message "Removing existing box: $BOX_NAME"
+  aws s3 rm "s3://laptop-boxes/$BOX_NAME" \
+    || failure_message "Could not remove $BOX_NAME"
+
+  message "Moving new box to correct location: $BOX_NAME"
+  aws s3 mv "s3://laptop-boxes/$BOX_NAME.tmp" "s3://laptop-boxes/$BOX_NAME" \
+    --acl public-read || failure_message 'Could not move new box into place on s3'
+}
+
+remove_test_success_tracker(){
+  rm "./test/succeeded.$LAPTOP_BASENAME"
+}
+
+publish_box(){
+  set_box_names
+
+  upload_box_to_temp_location && \
+    move_box_into_place && \
+    remove_test_success_tracker
+}
+
+check_for_aws
+
+for vagrantfile in test/succeeded.*; do
+  if [ -e "$vagrantfile" ]; then
+    publish_box
+  fi
+done

--- a/test/runner.sh
+++ b/test/runner.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env sh
-message() {
-  printf "\e[1;34m:: \e[1;37m%s\e[0m\n" "$*"
-}
+source ./test/common
 
-failure() {
-  printf "\n\e[1;31mFAILURE\e[0m: \e[1;37m%s\e[0m\n\n" "$*" >&2;
-  continue
-}
+FAILED=false
 
 vagrant_destroy() {
   if [ -z "$KEEP_VM" ]; then
@@ -14,48 +9,65 @@ vagrant_destroy() {
   fi
 }
 
+if ! vagrant -v | grep -qiE 'Vagrant 1.5'; then
+  failure_message 'You must use vagrant >= 1.5.0 to run the test suite.'
+  exit 1
+fi
+
 message "Building latest scripts"
 ./bin/build.sh
 
 for vagrantfile in test/Vagrantfile.*; do
+  FAILED=false
+
   message "Testing with $vagrantfile"
 
-  ln -sf "$vagrantfile" ./Vagrantfile || failure 'Unable to link Vagrantfile'
+  ln -sf "$vagrantfile" ./Vagrantfile || failure "Unable to link Vagrantfile $vagrantfile"
 
   message 'Destroying and recreating virtual machine'
   vagrant_destroy
-  vagrant up || failure 'Unable to start virtual machine'
+  vagrant up || failure "$vagrantfile :: Unable to start virtual machine"
 
   # TODO: Create a Vagrantfile.mac that uses VMWare Fusion to run OSX
   if echo "$vagrantfile" | grep -q '\.mac$'; then
     vagrant ssh -c 'echo vagrant | bash /vagrant/mac' \
-      || failure 'Installation script failed to run'
+      || failure "$vagrantfile :: Installation script failed to run"
   else
     vagrant ssh -c 'echo vagrant | bash /vagrant/linux' \
-      || failure 'Installation script failed to run'
+      || failure "$vagrantfile :: Installation script failed to run"
   fi
 
   vagrant ssh -c '[ "$SHELL" = "/usr/bin/zsh" ]' \
-    || failure 'Installation did not set $SHELL to ZSH'
+    || failure "$vagrantfile :: Installation did not set \$SHELL to ZSH"
 
   ruby_version="$(curl -sSL http://ruby.thoughtbot.com/latest)"
 
   vagrant ssh -c 'zsh -i -l -c "ruby --version" | grep -Fq "$ruby_version"' \
-    || failure 'Installation did not install the correct ruby'
+    || failure "$vagrantfile :: Installation did not install the correct ruby"
 
   vagrant ssh -c 'zsh -i -l -c "rm -Rf ~/test_app && cd ~ && rails new test_app"' \
-    || failure 'Could not successfully create a rails app'
+    || failure "$vagrantfile :: Could not successfully create a rails app"
 
   vagrant ssh -c 'zsh -i -l -c "cd ~/test_app && rails g scaffold post title:string"' \
-    || failure 'Could not successfully generate a scaffolded model'
+    || failure "$vagrantfile :: Could not successfully generate a scaffolded model"
 
   vagrant ssh -c 'zsh -i -l -c "cd ~/test_app && rake db:create db:migrate db:test:prepare"' \
-    || failure 'Could not successfully initialize databases and migrate'
+    || failure "$vagrantfile :: Could not successfully initialize databases and migrate"
 
-  message "$vagrantfile tested successfully, shutting down VM"
+  vagrant ssh -c 'zsh -i -l -c "rm -Rf ~/test_app"'
+  vagrant ssh -c 'zsh -i -l -c "sudo aptitude clean"'
+
+  if [ "$FAILED" = true ]; then
+    failure_message "$vagrantfile :: The automated tests failed. Please look for error messages above"
+  else
+    message "$vagrantfile tests succeeded"
+    if [ -n "$PACKAGE_BOXES" ];
+      package_box
+    fi
+  fi
+
   vagrant halt
   sleep 30
   vagrant_destroy
   sleep 30
 done
-


### PR DESCRIPTION
Vagrant boxes can be created automatically after a successful run of the
laptop test suite. These vagrant boxes are published to
[vagrantcloud](http://vagrantcloud.com/thoughtbot/) and should be a solid
start on a vagrant dev box suitable for modern ruby and ruby-on-rails
development.

Improvements include:
- Vagrantfiles fixed to have predictable names
- test/runner.sh now knows how to publish a box to s3
- Secrets for publishers extracted into ~/.laptop.secrets
- Error reporting improvements
- Full documentation on creating new base boxes

We now require vagrant >= 1.5.0 to use the automated test suite built into
laptop.
