### PR TITLE
Making brew commands work in non-pristine envs

### DIFF
--- a/Manifest.mac
+++ b/Manifest.mac
@@ -4,6 +4,7 @@ common-components/exit-trap
 common-components/check-home-bin
 common-components/shared-functions
 common-components/zsh
+mac-components/mac-functions
 mac-components/zsh-fix
 mac-components/homebrew
 mac-components/packages

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -14,5 +14,5 @@ for MANIFEST in Manifest.*; do
     printf "### end $file\n\n" >> "$FILENAME"
   done < "$MANIFEST"
 
-  chmod 755 $FILENAME
+  chmod 755 "$FILENAME"
 done

--- a/common-components/shared-functions
+++ b/common-components/shared-functions
@@ -1,7 +1,3 @@
 fancy_echo() {
   printf "\n%b\n" "$1"
 }
-
-brew_install() {
-  brew install $1 || brew update $1
-}

--- a/linux
+++ b/linux
@@ -30,10 +30,6 @@ fi
 fancy_echo() {
   printf "\n%b\n" "$1"
 }
-
-brew_install() {
-  brew install $1 || brew update $1
-}
 ### end common-components/shared-functions
 
 if ! grep -qiE 'wheezy|jessie|precise|saucy|trusty' /etc/os-release; then

--- a/mac
+++ b/mac
@@ -30,15 +30,21 @@ fi
 fancy_echo() {
   printf "\n%b\n" "$1"
 }
-
-brew_install() {
-  brew install $1 || brew update $1
-}
 ### end common-components/shared-functions
 
 fancy_echo "Changing your shell to zsh ..."
   chsh -s $(which zsh)
 ### end common-components/zsh
+
+brew_install() {
+  if ! brew list -1 | grep -q '^'"$1"'\$'; then
+    echo "brew upgrade $@"
+    (brew upgrade $@) || echo ''
+  else
+    brew install $@
+  fi
+}
+### end mac-components/mac-functions
 
 if [[ -f /etc/zshenv ]]; then
   fancy_echo "Fixing OSX zsh environment bug ..."
@@ -65,37 +71,34 @@ brew update
 ### end mac-components/homebrew
 
 fancy_echo "Installing Postgres, a good open source relational database ..."
-  brew install postgres --no-python
+  brew_install 'postgres' '--no-python'
 
 fancy_echo "Installing Redis, a good key-value database ..."
-  brew install redis
+  brew_install 'redis'
 
 fancy_echo "Installing The Silver Searcher (better than ack or grep) to search the contents of files ..."
-  brew install the_silver_searcher
+  brew_install 'the_silver_searcher'
 
 fancy_echo "Installing vim from Homebrew to get the latest version ..."
-  brew install vim
+  brew_install 'vim'
 
 fancy_echo "Installing ctags, to index files for vim tab completion of methods, classes, variables ..."
-  brew install ctags
+  brew_install 'ctags'
 
 fancy_echo "Installing tmux, to save project state and switch between projects ..."
-  brew install tmux
+  brew_install 'tmux'
 
 fancy_echo "Installing reattach-to-user-namespace, for copy-paste and RubyMotion compatibility with tmux ..."
-  brew install reattach-to-user-namespace
+  brew_install 'reattach-to-user-namespace'
 
 fancy_echo "Installing ImageMagick, to crop and resize images ..."
-  brew install imagemagick
+  brew_install 'imagemagick'
 
 fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integration testing ..."
-  brew install qt
+  brew_install 'qt'
 
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
-  brew install watch
-
-fancy_echo "Installing Go..."
-  brew_install 'go'
+  brew_install 'watch'
 ### end mac-components/packages
 
 fancy_echo "Starting Postgres ..."

--- a/mac-components/mac-functions
+++ b/mac-components/mac-functions
@@ -1,0 +1,7 @@
+brew_install() {
+  if ! brew list -1 | grep -q '^'"$1"'\$'; then
+    (brew upgrade $@) || echo ''
+  else
+    brew install $@
+  fi
+}

--- a/mac-components/packages
+++ b/mac-components/packages
@@ -1,32 +1,29 @@
 fancy_echo "Installing Postgres, a good open source relational database ..."
-  brew install postgres --no-python
+  brew_install 'postgres' '--no-python'
 
 fancy_echo "Installing Redis, a good key-value database ..."
-  brew install redis
+  brew_install 'redis'
 
 fancy_echo "Installing The Silver Searcher (better than ack or grep) to search the contents of files ..."
-  brew install the_silver_searcher
+  brew_install 'the_silver_searcher'
 
 fancy_echo "Installing vim from Homebrew to get the latest version ..."
-  brew install vim
+  brew_install 'vim'
 
 fancy_echo "Installing ctags, to index files for vim tab completion of methods, classes, variables ..."
-  brew install ctags
+  brew_install 'ctags'
 
 fancy_echo "Installing tmux, to save project state and switch between projects ..."
-  brew install tmux
+  brew_install 'tmux'
 
 fancy_echo "Installing reattach-to-user-namespace, for copy-paste and RubyMotion compatibility with tmux ..."
-  brew install reattach-to-user-namespace
+  brew_install 'reattach-to-user-namespace'
 
 fancy_echo "Installing ImageMagick, to crop and resize images ..."
-  brew install imagemagick
+  brew_install 'imagemagick'
 
 fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integration testing ..."
-  brew install qt
+  brew_install 'qt'
 
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
-  brew install watch
-
-fancy_echo "Installing Go..."
-  brew_install 'go'
+  brew_install 'watch'


### PR DESCRIPTION
I made the following changes:
1. Included golang. Who doesn't like go? :smile:
2. Set mac / linux scripts with executable perms
3. Added a graceful brew_install function that won't fail on
   already installed components
