### PR TITLE
Support rerunning the installation script by restarting postgresql.

### DIFF
--- a/mac
+++ b/mac
@@ -92,7 +92,7 @@ fancy_echo "Installing watch, to execute a program periodically and show the out
 ### end mac-components/packages
 
 fancy_echo "Starting Postgres ..."
-  brew services start postgres
+  brew services restart postgresql
 ### end mac-components/start-services
 
 fancy_echo "Installing rbenv, to change Ruby versions ..."

--- a/mac-components/start-services
+++ b/mac-components/start-services
@@ -1,2 +1,2 @@
 fancy_echo "Starting Postgres ..."
-  brew services start postgres
+  brew services restart postgresql


### PR DESCRIPTION
If postgresql was installed and started in a previous run, start causes:
Error: Service `postgresql` already started, use `brew services restart postgresql`

When developing changes to these scripts, it's important to be able to run and rerun this script without removing applications.
