### PR TITLE
Update mac

### DIFF
--- a/mac
+++ b/mac
@@ -90,7 +90,7 @@ fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integ
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   brew install watch
 
-node_version = "0.10.28"
+node_version="0.10.28"
 
 if ! command -v nvm &>/dev/null; then
   fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing JavaScript packages ..."


### PR DESCRIPTION
Remove spaces in node_version variable definition. I kept getting an error that node_version command was not found on line 93. This cleared things right up.
