### PR TITLE
Editing rbenv in mac to fix zsh error

### DIFF
--- a/mac
+++ b/mac
@@ -125,10 +125,10 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
 
   if ! grep -qs "rbenv init" ~/.zshrc; then
     printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> ~/.zshrc
-    printf 'eval "$(rbenv init - --no-rehash)"\n' >> ~/.zshrc
+    printf 'eval "$(rbenv init - zsh --no-rehash)"\n' >> ~/.zshrc
 
     fancy_echo "Enable shims and autocompletion ..."
-      eval "$(rbenv init -)"
+      eval "$(rbenv init - zsh)"
   fi
 
   export PATH="$HOME/.rbenv/bin:$PATH"

--- a/mac-components/rbenv
+++ b/mac-components/rbenv
@@ -3,10 +3,10 @@ fancy_echo "Installing rbenv, to change Ruby versions ..."
 
   if ! grep -qs "rbenv init" ~/.zshrc; then
     printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> ~/.zshrc
-    printf 'eval "$(rbenv init - --no-rehash)"\n' >> ~/.zshrc
+    printf 'eval "$(rbenv init - zsh --no-rehash)"\n' >> ~/.zshrc
 
     fancy_echo "Enable shims and autocompletion ..."
-      eval "$(rbenv init -)"
+      eval "$(rbenv init - zsh)"
   fi
 
   export PATH="$HOME/.rbenv/bin:$PATH"


### PR DESCRIPTION
Clean install on OSX Mavericks 10.9.4, I encountered an error similar to this one: https://github.com/sstephenson/rbenv/issues/487

Implemented same zsh fix, seemed to work alright. I think this is what needs to be changed in the code. The closed rbenv issue seems to say it was fixed on their end back in November, so maybe just a path needs updating, too. 
