### PR TITLE
Use root to run the installer(1)

### DIFF
--- a/mac
+++ b/mac
@@ -182,7 +182,7 @@ fancy_echo "Installing the heroku-config plugin to pull config variables locally
 
 fancy_echo "Installing foreman ..."
   curl -sLo /tmp/foreman.pkg http://assets.foreman.io/foreman/foreman.pkg && \
-  installer -pkg /tmp/foreman.pkg -tgt /
+  sudo installer -pkg /tmp/foreman.pkg -tgt /
 ### end mac-components/heroku
 
 fancy_echo "Installing GitHub CLI client ..."

--- a/mac-components/heroku
+++ b/mac-components/heroku
@@ -6,4 +6,4 @@ fancy_echo "Installing the heroku-config plugin to pull config variables locally
 
 fancy_echo "Installing foreman ..."
   curl -sLo /tmp/foreman.pkg http://assets.foreman.io/foreman/foreman.pkg && \
-  installer -pkg /tmp/foreman.pkg -tgt /
+  sudo installer -pkg /tmp/foreman.pkg -tgt /


### PR DESCRIPTION
We merged the prior branch too quickly, so please try this on OS X before it gets merged.
