### PR TITLE
Repackage base boxes, used by rspec tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -99,6 +99,22 @@ given that we're dealing with an entire operating system.
 - Remove the box config in vagrantcloud
 - Update README.md
 
+## Repackaging base boxes
+
+You might want to repackage base boxes on occasion to make running the
+automated suite faster. There will be fewer updates to apply, and sometimes
+vendor-supplied updates do not apply cleanly in a non-interactive shell.
+
+```sh
+./bin/repackage_base_boxes.sh
+```
+This will iterate over `spec/vagrantfiles/Vagrantfile.*`, spin up a VM, drop
+you into an interactive shell and then give you the option to repackage
+afterwards.  It will skip any boxes that already exist in the project root,
+similar to behavior of the rspec suite.
+
+After repackaging, use `./bin/publish_laptopped_boxes.sh` to publish to aws.
+
 ## Creating new base boxes to test a new release
 
 1. Download a 64 bit minimal server ISO

--- a/bin/publish_laptopped_boxes.sh
+++ b/bin/publish_laptopped_boxes.sh
@@ -1,6 +1,7 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
 check_for_aws() {
-  if ! command -v aws &>/dev/null; then
+  if ! command -v aws >/dev/null; then
     failure_message 'You must install aws-cli to publish boxes'
     exit 1
   fi
@@ -34,10 +35,10 @@ publish_box(){
 }
 
 box_has_changed() {
-  local remote_size=$(aws s3 ls "laptop-boxes/$box" | cut -f 3 -d ' ')
+  local remote_size=$(aws s3 ls "laptop-boxes/$box" | sed "s/  / /" | cut -f 3 -d ' ')
   local local_size=$(stat -c %s "$box")
 
-  [ "$local_size" -ne "$remote_size" ]
+  [ "$local_size" != "$remote_size" ]
 }
 
 ###################################

--- a/bin/repackage_base_boxes.sh
+++ b/bin/repackage_base_boxes.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+for box in spec/vagrantfiles/Vagrantfile.*; do
+  base_name=$(basename "$box" '.box' | sed "s/Vagrantfile\.//")
+  box_file="${base_name}.box"
+
+  if [ ! -e "$box_file" ]; then
+    ln -sf $box Vagrantfile
+
+    vagrant destroy
+    vagrant up
+    echo "You'll now be dropped into an interactive shell in $base_name."
+    echo "Make whatever changes are necessary and when you exit we'll repackage the box."
+    vagrant ssh
+
+    rm -f "$box_file"
+    vagrant package --base "laptop-$base_name" --output "$box_file"
+
+  else
+    echo "$base_name already packaged at $box_file, skipping"
+  fi
+done


### PR DESCRIPTION
This allows us to more easily repackage and republish base boxes used in the
rspec test suite.
