### PR TITLE
Switch to launchctl for Postgres

### DIFF
--- a/mac
+++ b/mac
@@ -116,8 +116,13 @@ fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing Ja
   nvm alias default "$node_version"
 ### end mac-components/packages
 
+fancy_echo "Ensure LaunchAgents exists ..."
+  mkdir -p ~/Library/LaunchAgents
+
 fancy_echo "Starting Postgres ..."
-  brew services restart postgresql
+  ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist >/dev/null
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist >/dev/null
 ### end mac-components/start-services
 
 fancy_echo "Installing rbenv, to change Ruby versions ..."

--- a/mac-components/start-services
+++ b/mac-components/start-services
@@ -1,2 +1,7 @@
+fancy_echo "Ensure LaunchAgents exists ..."
+  mkdir -p ~/Library/LaunchAgents
+
 fancy_echo "Starting Postgres ..."
-  brew services restart postgresql
+  ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
+  launchctl unload ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist >/dev/null
+  launchctl load ~/Library/LaunchAgents/homebrew.mxcl.postgresql.plist >/dev/null


### PR DESCRIPTION
`brew services` is no longer supported:

https://github.com/Homebrew/homebrew/commit/c0b99c031fec0a2096b85a458d7b42e3627560d8

Also fixes #93 and #243.

Idempotently creates Postgres database cluster and starts (or restarts)
Postgres.
