### PR TITLE
Update prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Installer](https://github.com/kennethreitz/osx-gcc-installer/).
 For Lion (10.7) or Mountain Lion (10.8): use [Command Line Tools for
 XCode](https://developer.apple.com/downloads/index.action).
 
-For Mavericks (10.9): run `sudo xcodebuild -license` and follow the instructions
-to accept the XCode agreement.  Then run `xcode-select --install` in your
-terminal and then click "Install".
+For Mavericks (10.9): installed with the script, no prerequisite.
 
 ### Linux
 
@@ -103,29 +101,18 @@ Put your customizations in `~/.laptop.local`. For example, your
 You should write your customizations such that they can be run safely more than
 once. See the `mac` and `linux` scripts for examples.
 
-Laptopped linux vagrant boxes
------------------------------------------------------------
+Laptopped Linux Vagrant boxes
+-----------------------------
 
-We now publish [vagrant](http://vagrantup.com) boxes for every supported linux
+We now publish [Vagrant](http://vagrantup.com) boxes for every supported Linux
 distro. These boxes have the laptop script applied already and are ready to go.
-Getting started is as easy as creating a Vagrantfile that looks like:
 
-    Vagrant.configure('2') do |config|
-      config.vm.box = 'thoughtbot/ubuntu-14-04-server-with-laptop'
-    end
+Create a Vagrantfile:
 
-
-```sh
-# And then in the same directory as your Vagrantfile . . .
-vagrant up
-vagrant ssh
-
-```
-
-You can also use `vagrant init`:
-
-    # In your project directory
     vagrant init thoughtbot/ubuntu-14-04-server-with-laptop
+
+In the same directory as your Vagrantfile:
+
     vagrant up
     vagrant ssh
 
@@ -138,7 +125,7 @@ Laptopped vagrantcloud boxes currently available:
 * `thoughtbot/ubuntu-12-04-server-with-laptop`
 
 See our [vagrantcloud profile](https://vagrantcloud.com/thoughtbot). You must
-have vagrant >= 1.5.0 to use vagrantcloud images directly.
+have Vagrant >= 1.5.0 to use vagrantcloud images directly.
 
 Credits
 -------


### PR DESCRIPTION
Homebrew's install script checks whether the command line tools are installed,
and, only if necessary, will run `xcode-select --install`.

https://github.com/Homebrew/homebrew/blob/go/install#L162

The test they are using depends in part on a heuristic:

Homebrew/homebrew@afa4549

I confirmed that it works on a clean 10.9 install.

We also should not instruct the user to run `sudo xcodebuild -license` at all.

Here's why:

The `xcodebuild program` isn't included in OS X Mavericks. When you run
`xcodebuild`, you're actually finding one of 83 shims found in `/usr/bin` that
are included in Mavericks. These shims are an important part of how the
`xcode-select` mechanism works. When the command line developer tools have not
been installed, invoking any of these shims won't do anything other than prompt
you to install the command line developer tools:

```
$ xcodebuild -license
xcode-select: note: no developer tools were found at
'/Applications/Xcode.app', requesting install.
Choose an option in the dialog to download the command line developer tools.
```

(And, the GUI install dialog is presented.)

Of course, since the real `xcodebuild` program isn't actually available, it
doesn't make sense to try and use it to accept the Xcode License Agreement.

Instead, go straight to installing with `xcode-select --install` (xcode-select
comes with OS X Mavericks and is not a shim):

```
$ xcode-select --install
xcode-select: note: install requested for command line developer tools
```

And, the exact same GUI install dialog is presented (prompting the user to
either "Get Xcode" from the App Store or immediately "Install" the command line
developer tools).

For more about `xcode-select` and it's shims, see `man xcode-select`.

This also removes redundant Vagrant setup instructions and capitalize Vagrant.
