### PR TITLE
Add compatibility for Bash 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Install
 
 Read, then run the script:
 
-    bash <(curl -s https://raw.githubusercontent.com/thoughtbot/laptop/master/mac) |& tee ~/laptop.log
+    bash <(curl -s https://raw.githubusercontent.com/thoughtbot/laptop/master/mac) 2>&1 | tee ~/laptop.log
 
 ### Linux
 
 Read, then run the script:
 
-    bash <(wget -qO- https://raw.githubusercontent.com/thoughtbot/laptop/master/linux) |& tee ~/laptop.log
+    bash <(wget -qO- https://raw.githubusercontent.com/thoughtbot/laptop/master/linux) 2>&1 | tee ~/laptop.log
 
 Debugging
 ---------


### PR DESCRIPTION
The `|&` token is new in Bash 4, which is not the default on Macs (I'm not sure about Linux). Given that laptop is meant to be run on a fresh machine, `2>&1 |` seems preferable, since it'll work on the Bash 3.x, which is what comes installed by default. 

re: http://github.com/thoughtbot/laptop/issues/268
