### PR TITLE
Switch from `hub` to `gh`

### DIFF
--- a/Manifest.mac
+++ b/Manifest.mac
@@ -15,6 +15,5 @@ common-components/ruby-environment
 mac-components/bundler
 common-components/default-gems
 mac-components/heroku
-mac-components/github
 mac-components/rcm
 common-components/personal-additions

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ What it sets up
 * [Bundler] for managing Ruby libraries
 * [Exuberant Ctags] for indexing files for vim tab completion
 * [Foreman] for serving Rails apps locally
+* [gh] for interacting with the GitHub API
 * [Heroku Config] for local `ENV` variables
 * [Heroku Toolbelt] for interacting with the Heroku API
-* [Hub] for interacting with the GitHub API
 * [Homebrew] for managing operating system libraries (OS X only)
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
@@ -77,9 +77,9 @@ What it sets up
 [Bundler]: http://bundler.io/
 [Exuberant Ctags]: http://ctags.sourceforge.net/
 [Foreman]: https://github.com/ddollar/foreman
+[gh]: https://github.com/jingweno/gh
 [Heroku Config]: https://github.com/ddollar/heroku-config
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
-[Hub]: https://hub.github.com/
 [Homebrew]: http://brew.sh/
 [ImageMagick]: http://www.imagemagick.org/
 [Node.js]: http://nodejs.org/

--- a/lib/distro.rb
+++ b/lib/distro.rb
@@ -63,6 +63,10 @@ class Distro
     run_vagrant_ssh_command('command -v ag')
   end
 
+  def gh_test
+    run_vagrant_ssh_command('command -v gh')
+  end
+
   def package
     run_vagrant_ssh_command('rm -Rf ~/test_app')
     run_vagrant_ssh_command('sudo aptitude clean')

--- a/linux
+++ b/linux
@@ -179,8 +179,19 @@ fancy_echo "Installing the heroku-config plugin to pull config variables locally
 ### end linux-components/heroku
 
 fancy_echo "Installing GitHub CLI client ..."
-  curl http://hub.github.com/standalone -sLo ~/.bin/hub
-  chmod +x ~/.bin/hub
+  version="$(curl https://github.com/jingweno/gh/releases/latest -s | cut -d'v' -f2 | cut -d'"' -f1)"
+
+  if uname -m | grep -Fq 'x86_64'; then
+    arch='amd64'
+  else
+    arch='i386'
+  fi
+
+  cd /tmp
+  url="https://github.com/jingweno/gh/releases/download/v${version}/gh_${version}_${arch}.deb"
+  curl "$url" -sLo gh.deb
+  sudo dpkg -i gh.deb
+  cd -
 ### end linux-components/github
 
 fancy_echo "Installing rcm, to manage your dotfiles ..."

--- a/linux-components/github
+++ b/linux-components/github
@@ -1,3 +1,14 @@
 fancy_echo "Installing GitHub CLI client ..."
-  curl http://hub.github.com/standalone -sLo ~/.bin/hub
-  chmod +x ~/.bin/hub
+  version="$(curl https://github.com/jingweno/gh/releases/latest -s | cut -d'v' -f2 | cut -d'"' -f1)"
+
+  if uname -m | grep -Fq 'x86_64'; then
+    arch='amd64'
+  else
+    arch='i386'
+  fi
+
+  cd /tmp
+  url="https://github.com/jingweno/gh/releases/download/v${version}/gh_${version}_${arch}.deb"
+  curl "$url" -sLo gh.deb
+  sudo dpkg -i gh.deb
+  cd -

--- a/mac
+++ b/mac
@@ -132,6 +132,9 @@ fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integ
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   brew_install_or_upgrade 'watch'
 
+fancy_echo "Installing GitHub CLI client ..."
+  brew_install_or_upgrade 'gh'
+
 node_version="0.10"
 
 fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing JavaScript packages ..."
@@ -217,10 +220,6 @@ fancy_echo "Installing foreman ..."
   curl -sLo /tmp/foreman.pkg http://assets.foreman.io/foreman/foreman.pkg && \
   sudo installer -pkg /tmp/foreman.pkg -tgt /
 ### end mac-components/heroku
-
-fancy_echo "Installing GitHub CLI client ..."
-  brew_install_or_upgrade 'hub'
-### end mac-components/github
 
 if ! command -v rcup >/dev/null; then
   fancy_echo "Installing rcm, to manage your dotfiles ..."

--- a/mac-components/github
+++ b/mac-components/github
@@ -1,2 +1,0 @@
-fancy_echo "Installing GitHub CLI client ..."
-  brew_install_or_upgrade 'hub'

--- a/mac-components/packages
+++ b/mac-components/packages
@@ -28,6 +28,9 @@ fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integ
 fancy_echo "Installing watch, to execute a program periodically and show the output ..."
   brew_install_or_upgrade 'watch'
 
+fancy_echo "Installing GitHub CLI client ..."
+  brew_install_or_upgrade 'gh'
+
 node_version="0.10"
 
 fancy_echo "Installing NVM, Node.js, and NPM, for running apps and installing JavaScript packages ..."

--- a/spec/laptop_spec.rb
+++ b/spec/laptop_spec.rb
@@ -30,6 +30,7 @@ describe 'Laptop applied to a vagrant box' do
       expect { distro.scaffold_and_model_generation }.not_to raise_error
       expect { distro.database_migration }.not_to raise_error
       expect { distro.silver_searcher_test }.not_to raise_error
+      expect { distro.gh_test }.not_to raise_error
 
       puts "Packaging box for distribution"
 


### PR DESCRIPTION
[gh](https://github.com/jingweno/gh) is a [hub](https://github.com/github/hub) reimplementation that's much faster and is now the official
Github CLI. It appears that "hub" is [deprecated](https://github.com/github/hub/issues/475).
