### PR TITLE
Make `brew_is_upgradable` mac function more robust

### DIFF
--- a/mac
+++ b/mac
@@ -55,10 +55,8 @@ brew_is_installed() {
 brew_is_upgradable() {
   local NAME=$(brew_expand_alias "$1")
 
-  local INSTALLED=$(brew ls --versions "$NAME" | awk '{print $NF}')
-  local LATEST=$(brew info "$NAME" 2>/dev/null | head -1 | awk '{gsub(/,/, ""); print $3}')
-
-  [ "$INSTALLED" != "$LATEST" ]
+  brew outdated --quiet "$NAME" >/dev/null
+  [[ $? -ne 0 ]]
 }
 
 brew_expand_alias() {

--- a/mac-components/mac-functions
+++ b/mac-components/mac-functions
@@ -17,10 +17,8 @@ brew_is_installed() {
 brew_is_upgradable() {
   local NAME=$(brew_expand_alias "$1")
 
-  local INSTALLED=$(brew ls --versions "$NAME" | awk '{print $NF}')
-  local LATEST=$(brew info "$NAME" 2>/dev/null | head -1 | awk '{gsub(/,/, ""); print $3}')
-
-  [ "$INSTALLED" != "$LATEST" ]
+  brew outdated --quiet "$NAME" >/dev/null
+  [[ $? -ne 0 ]]
 }
 
 brew_expand_alias() {


### PR DESCRIPTION
Rely on logic of `brew outdated` to decide whether a brew is upgradable.

Fixes #276 and #282:
- https://github.com/thoughtbot/laptop/issues/276
- https://github.com/thoughtbot/laptop/issues/282
