### PR TITLE
Install Postgres via Hombrew bottle

### DIFF
--- a/mac
+++ b/mac
@@ -103,7 +103,7 @@ brew update
 ### end mac-components/homebrew
 
 fancy_echo "Installing Postgres, a good open source relational database ..."
-  brew_install_or_upgrade 'postgres' '--no-python'
+  brew_install_or_upgrade 'postgres'
 
 fancy_echo "Installing Redis, a good key-value database ..."
   brew_install_or_upgrade 'redis'

--- a/mac-components/packages
+++ b/mac-components/packages
@@ -1,5 +1,5 @@
 fancy_echo "Installing Postgres, a good open source relational database ..."
-  brew_install_or_upgrade 'postgres' '--no-python'
+  brew_install_or_upgrade 'postgres'
 
 fancy_echo "Installing Redis, a good key-value database ..."
   brew_install_or_upgrade 'redis'


### PR DESCRIPTION
Upstream maintainers put thought into what is and what isn't sensible to
include by default. Those decisions establish a de facto standard that is
broader in scope than Laptop: Homebrew users, library users, etc.

The further we stray from the defaults, the more likely we are to run into
problems, and those problems will be harder.

The most widely experienced, most urgent, and most rapidly fixed problems will
be problems with installing using formula defaults. Problems from using
non-defaults are relatively lonely.

Also, Homebrew bottles are awesome:

https://github.com/Homebrew/homebrew/wiki/FAQ#why-do-you-compile-everything

Using options forces an install from source rather than a bottle, which is
much, much slower:

> Options were passed to the install command i.e. `brew install
> $FORMULA` will use a bottled version of `$FORMULA`, but `brew install
> $FORMULA --enable-bar` will trigger a source build.
