### PR TITLE
Fixes rbenv component path in the manifest files

### DIFF
--- a/Manifest.linux
+++ b/Manifest.linux
@@ -8,7 +8,7 @@ linux-components/debian-package-update
 linux-components/debian-derivative-packages
 common-components/zsh
 linux-components/silver-searcher
-linux-components/rbenv
+common-components/rbenv
 common-components/ruby-environment
 linux-components/bundler
 common-components/default-gems

--- a/Manifest.mac
+++ b/Manifest.mac
@@ -9,7 +9,7 @@ mac-components/zsh-fix
 mac-components/homebrew
 mac-components/packages
 mac-components/start-services
-mac-components/rbenv
+common-components/rbenv
 mac-components/compiler-and-libraries
 common-components/ruby-environment
 mac-components/bundler

--- a/linux
+++ b/linux
@@ -118,7 +118,31 @@ if ! command -v ag >/dev/null; then
 fi
 ### end linux-components/silver-searcher
 
-### end linux-components/rbenv
+if [[ ! -d "$HOME/.rbenv" ]]; then
+  fancy_echo "Installing rbenv, to change Ruby versions ..."
+    git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
+
+    if ! grep -qs "rbenv init" ~/.zshrc; then
+      printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> ~/.zshrc
+      printf 'eval "$(rbenv init - zsh --no-rehash)"\n' >> ~/.zshrc
+    fi
+
+    export PATH="$HOME/.rbenv/bin:$PATH"
+    eval "$(rbenv init - zsh)"
+fi
+
+if [[ ! -d "$HOME/.rbenv/plugins/rbenv-gem-rehash" ]]; then
+  fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
+    git clone https://github.com/sstephenson/rbenv-gem-rehash.git \
+      ~/.rbenv/plugins/rbenv-gem-rehash
+fi
+
+if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
+  fancy_echo "Installing ruby-build, to install Rubies ..."
+    git clone https://github.com/sstephenson/ruby-build.git \
+      ~/.rbenv/plugins/ruby-build
+fi
+### end common-components/rbenv
 
 ruby_version="$(curl -sSL http://ruby.thoughtbot.com/latest)"
 

--- a/mac
+++ b/mac
@@ -156,7 +156,31 @@ fancy_echo "Starting Postgres ..."
   brew_launchctl_restart postgresql
 ### end mac-components/start-services
 
-### end mac-components/rbenv
+if [[ ! -d "$HOME/.rbenv" ]]; then
+  fancy_echo "Installing rbenv, to change Ruby versions ..."
+    git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
+
+    if ! grep -qs "rbenv init" ~/.zshrc; then
+      printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> ~/.zshrc
+      printf 'eval "$(rbenv init - zsh --no-rehash)"\n' >> ~/.zshrc
+    fi
+
+    export PATH="$HOME/.rbenv/bin:$PATH"
+    eval "$(rbenv init - zsh)"
+fi
+
+if [[ ! -d "$HOME/.rbenv/plugins/rbenv-gem-rehash" ]]; then
+  fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
+    git clone https://github.com/sstephenson/rbenv-gem-rehash.git \
+      ~/.rbenv/plugins/rbenv-gem-rehash
+fi
+
+if [[ ! -d "$HOME/.rbenv/plugins/ruby-build" ]]; then
+  fancy_echo "Installing ruby-build, to install Rubies ..."
+    git clone https://github.com/sstephenson/ruby-build.git \
+      ~/.rbenv/plugins/ruby-build
+fi
+### end common-components/rbenv
 
 fancy_echo "Upgrading and linking OpenSSL ..."
   brew_install_or_upgrade 'openssl'


### PR DESCRIPTION
Commit bc5a7c6be77b12e5181e3af37d749b836da9d759 changed the way rbenv is
installed ("Use the same Git/GitHub approach for Mac as we do for Linux."), but
was missing the changes in the manifest files. This commit fixes the
corresponding manifest files:
- changes mac-components/rbenv to common-components/rbenv in Manifest.mac
- changes linux-components/rbenv to common-components/rbenv in Manifest.linux
