### PR TITLE
Declare support for OS X Yosemite (and a nit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Requirements
 We support:
 
 * [OS X Mavericks (10.9)](https://itunes.apple.com/us/app/os-x-mavericks/id675248567)
+* OS X Yosemite (10.10)
 
 Older versions may work but aren't regularly tested. Bug reports for older
 versions are welcome.


### PR DESCRIPTION
Today I verified that, as of https://github.com/wellmadehq/laptop/commit/b16220326396fd9f7df3cf92b000a3a53dd88b96, Laptop succeeds on clean installs of both OS X Mavericks 10.9.5 and OS X Yosemite GM Candidate 1.0.

Here's my reasoning for stating support for OS X Yosemite now:
- Apple stated that the final release will be later this month ("late October"),
- Yosemite in GM Candidate release stage,
- Apple already asking devs to submit Mac Apps with Yosemite support (a solid indicator of immenemt launch of an Apple OS),
- and, Laptop installs successfully on it.

About the nit: Referring to the OS as "Mac OS X" seems dated to me and I guess is _technically_ wrong. In the couple years since Apple officially renamed the OS to simply "OS X" Apple and many others have been pretty consistent in their usage. (See the commit message for links to some sources supporting the current name and the name change.)

Aside: Bottles are used on Mavericks and the speedup was very noticeable — PostgreSQL and it's dependencies were "poured" from bottles: `ossp-uuid`, `openssl`, and `readline`. Before, these were all installed from source. On Yosemite, everything is built from source since Homebrew's bottle building bot [doesn't build bottles for Yosemite yet](https://github.com/Homebrew/homebrew/issues/29988#issuecomment-46892680). I'm sure it will soon, though.
