### PR TITLE
Fix append_to_zshrc

### DIFF
--- a/common-components/shared-functions
+++ b/common-components/shared-functions
@@ -12,6 +12,6 @@ append_to_zshrc() {
   fi
 
   if ! grep -Fqs "$text" "$zshrc"; then
-    printf "%s\n" "$text" >> "$zshrc"
+    echo -e "$text\n" >> "$zshrc"
   fi
 }

--- a/linux
+++ b/linux
@@ -12,7 +12,7 @@ append_to_zshrc() {
   fi
 
   if ! grep -Fqs "$text" "$zshrc"; then
-    printf "%s\n" "$text" >> "$zshrc"
+    echo -e  "$text\n" >> "$zshrc"
   fi
 }
 ### end common-components/shared-functions

--- a/mac
+++ b/mac
@@ -12,7 +12,7 @@ append_to_zshrc() {
   fi
 
   if ! grep -Fqs "$text" "$zshrc"; then
-    printf "%s\n" "$text" >> "$zshrc"
+    echo -e "$text\n" >> "$zshrc"
   fi
 }
 ### end common-components/shared-functions


### PR DESCRIPTION
This PR fixes a bug recently introduced by the new append_to_zshrc function in [this commit](https://github.com/thoughtbot/laptop/commit/4e7f598feea1668140395caea325bcc1adbc7470) by @kenyonj. 

"\n" were introduced and not escaped when this function was called. I then used echo -e instead of printf to properly interpret the input string. 
