### PR TITLE
PostgreSQL won't install on Yosemite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install
 
 Read, then run the script:
 
-    bash <(curl -s https://raw.githubusercontent.com/CaioBianchi/laptop/master/mac) 2>&1 | tee ~/laptop.log
+    bash <(curl -s https://raw.githubusercontent.com/thoughtbot/laptop/master/mac) 2>&1 | tee ~/laptop.log
 
 Debugging
 ---------


### PR DESCRIPTION
It seems that the version of Postgres in Homebrew's binaries has some sort of issue with tcl.
Adding the `--no-tcl` option to the install command seems to fix the problem, as kindly pointed out by @thoughtbot on Twitter (https://twitter.com/thoughtbot/status/522962926542389248)

```
Installing Postgres, a good open source relational database ...
==> Downloading http://ftp.postgresql.org/pub/source/v9.3.5/postgresql-9.3.5.tar.bz2
Already downloaded: /Library/Caches/Homebrew/postgresql-9.3.5.tar.bz2
==> Patching
patching file contrib/uuid-ossp/uuid-ossp.c
==> ./configure --prefix=/usr/local/Cellar/postgresql/9.3.5_1 --datadir=/usr/local/Cellar/postgresql/9.3.5_1/share/postgresql --docdir=/usr/local/Cellar/postgresql/9.3.5_1/share/doc/postgresql --enable-thread-safety --with-bonjour --with-gssapi --with-ldap --with-openssl --with-pam --with-libxml --with-libxslt --with-perl --with-tcl --with-tclconfig=/usr/lib --with-ossp-uuid
checking for POSIX signal interface... yes
checking for working memcmp... yes
checking for tclsh... /usr/bin/tclsh
checking for tclConfig.sh... no
configure: error: file 'tclConfig.sh' is required for Tcl

READ THIS: https://github.com/Homebrew/homebrew/wiki/troubleshooting

failed
```
