### PR TITLE
Don't use /etc/zshrc

### DIFF
--- a/mac
+++ b/mac
@@ -87,11 +87,6 @@ brew_launchctl_restart() {
   launchctl load ~/Library/LaunchAgents/$PLIST >/dev/null
 }
 
-if [[ -f /etc/zshenv ]]; then
-  fancy_echo "Fixing OSX zsh environment bug ..."
-    sudo mv /etc/{zshenv,zshrc}
-fi
-
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew, a good OS X package manager ..."
     ruby <(curl -fsS https://raw.githubusercontent.com/Homebrew/install/master/install)


### PR DESCRIPTION
- Using zshrc causes path_helper to override PATH from zshenv
- We set up rbenv among other things in zshenv

https://github.com/thoughtbot/dotfiles/pull/307
