### PR TITLE
Changes heroku-config plugin url to use https

### DIFF
--- a/mac
+++ b/mac
@@ -213,7 +213,7 @@ fancy_echo "Installing Heroku CLI client ..."
   brew_install_or_upgrade 'heroku-toolbelt'
 
 fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
-  heroku plugins:install git://github.com/ddollar/heroku-config.git
+  heroku plugins:install https://github.com/ddollar/heroku-config.git
 
 fancy_echo "Installing foreman ..."
   curl -sLo /tmp/foreman.pkg http://assets.foreman.io/foreman/foreman.pkg && \


### PR DESCRIPTION
Many corporate firewalls block the git:// protocol. Changing this uri to use https:// makes it usable for more people. Also the other git uris are all using https:// so this should be no exception.
