### PR TITLE
Use homebrew for rbenv and ruby-build

### DIFF
--- a/mac
+++ b/mac
@@ -153,30 +153,16 @@ fancy_echo "Starting Postgres ..."
 
 if [[ ! -d "$HOME/.rbenv" ]]; then
   fancy_echo "Installing rbenv, to change Ruby versions ..."
-    git clone https://github.com/sstephenson/rbenv.git "$HOME/.rbenv"
+    brew_install_or_upgrade 'rbenv' '--HEAD'
 
     append_to_zshrc 'export PATH="$HOME/.rbenv/bin:$PATH"'
     append_to_zshrc 'eval "$(rbenv init - zsh --no-rehash)"' 1
 
     export PATH="$HOME/.rbenv/bin:$PATH"
     eval "$(rbenv init - zsh)"
-fi
 
-rehash_path="$HOME/.rbenv/plugins/rbenv-gem-rehash"
-
-if [[ ! -d "$rehash_path" ]]; then
-  fancy_echo "Installing rbenv-gem-rehash so the shell automatically picks up binaries after installing gems with binaries..."
-    git clone https://github.com/sstephenson/rbenv-gem-rehash.git "$rehash_path"
-fi
-
-ruby_build_path="$HOME/.rbenv/plugins/ruby-build"
-
-if [[ -d "$ruby_build_path" ]]; then
-  fancy_echo "Updating to latest ruby-build..."
-  cd "$ruby_build_path" && git pull && cd -
-else
-  fancy_echo "Installing ruby-build..."
-  git clone https://github.com/sstephenson/ruby-build.git "$ruby_build_path"
+  fancy_echo "Installing ruby-build ..."
+    brew_install_or_upgrade 'ruby-build'
 fi
 
 fancy_echo "Upgrading and linking OpenSSL ..."


### PR DESCRIPTION
Is there any particular reason why homebrew isn't used in the formula for rbenv installation? This PR converts the rbenv / ruby-install installations to use brew (with `--HEAD` included for `rbenv` to maintain functionality, can be changed to stable if needed). Also, as of [rbenv@d1a039](https://github.com/sstephenson/rbenv/commit/d1a0398fdb99b548fd3846228e61f096b6982e60) `rbenv-gem-rehash` is no longer needed.
