### PR TITLE
Add $HOME/.rbenv to $PATH even if it's installed

### DIFF
--- a/mac
+++ b/mac
@@ -157,9 +157,6 @@ if [[ ! -d "$HOME/.rbenv" ]]; then
 
     append_to_zshrc 'export PATH="$HOME/.rbenv/bin:$PATH"'
     append_to_zshrc 'eval "$(rbenv init - zsh --no-rehash)"' 1
-
-    export PATH="$HOME/.rbenv/bin:$PATH"
-    eval "$(rbenv init - zsh)"
 fi
 
 rehash_path="$HOME/.rbenv/plugins/rbenv-gem-rehash"
@@ -184,6 +181,9 @@ fancy_echo "Upgrading and linking OpenSSL ..."
   brew unlink openssl && brew link openssl --force
 
 ruby_version="$(curl -sSL http://ruby.thoughtbot.com/latest)"
+
+export PATH="$HOME/.rbenv/bin:$PATH"
+eval "$(rbenv init - zsh)"
 
 fancy_echo "Installing Ruby $ruby_version ..."
   rbenv install -s "$ruby_version"


### PR DESCRIPTION
This should fix https://github.com/thoughtbot/laptop/issues/320 which is
happening since ~/.rbenv/bin was only added to the $PATH if we were
responsible for installing it, not if it already existed. This adds it
to the current shell regardless but does not add it to the user's zshrc
unless it wasn't previously installed.
