### PR TITLE
Remove Heroku Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ What it sets up
 * [Exuberant Ctags] for indexing files for vim tab completion
 * [Foreman] for serving Rails apps locally
 * [gh] for interacting with the GitHub API
-* [Heroku Config] for local `ENV` variables
 * [Heroku Toolbelt] for interacting with the Heroku API
 * [Homebrew] for managing operating system libraries
 * [ImageMagick] for cropping and resizing images
@@ -60,7 +59,6 @@ What it sets up
 [Exuberant Ctags]: http://ctags.sourceforge.net/
 [Foreman]: https://github.com/ddollar/foreman
 [gh]: https://github.com/jingweno/gh
-[Heroku Config]: https://github.com/ddollar/heroku-config
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [ImageMagick]: http://www.imagemagick.org/

--- a/mac
+++ b/mac
@@ -204,9 +204,6 @@ fancy_echo "Installing Parity, shell commands for development, staging, and prod
 fancy_echo "Installing Heroku CLI for managing Heroku apps and Foreman for managing app processes ..."
   brew_install_or_upgrade 'heroku-toolbelt'
 
-fancy_echo "Installing the heroku-config plugin to pull config variables locally to be used as ENV variables ..."
-  heroku plugins:install https://github.com/ddollar/heroku-config.git
-
 if ! command -v rcup >/dev/null; then
   fancy_echo "Installing rcm, to manage your dotfiles ..."
     brew tap thoughtbot/formulae


### PR DESCRIPTION
I haven't been using `heroku config:pull`, etc. for some time. Instead, I've
been using more targeted shell lines insides our
[`bin/setup`](http://robots.thoughtbot.com/bin-setup) convention, such as:

```
if ! grep -F "FILEPICKER" .env > /dev/null; then
 heroku config --remote staging | grep "FILEPICKER" >> .env
 sed -i '' 's/\:/=/' .env
 sed -i '' 's/ //g' .env
```

   fi

This is more targeted and automated than using `heroku config:pull`.
