### PR TITLE
Suggested installation includes an explicit review step

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ versions are welcome.
 Install
 -------
 
-Read, then run the script:
+Download, review, then execute the script:
 
-```bash
-bash <(curl -s https://raw.githubusercontent.com/thoughtbot/laptop/master/mac) 2>&1 | tee ~/laptop.log
+```sh
+curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/mac
+less mac
+bash mac 2>&1 | tee ~/laptop.log
 ```
 
 Debugging


### PR DESCRIPTION
While we did previously state "Read, then...", that's easier to ignore.
This brings the copy-pastable commands in line with the intent: to have
the user review the script before executing it. This also removes the
potentially confusing use of process substitution.

Note: The presence of `less` is assumed to avoid assumptions about
editors or the noise of handling that robustly (e.g. `${EDITOR:-vim}`)
