### PR TITLE
Install libyaml to avoid failed Ruby compilation

### DIFF
--- a/mac
+++ b/mac
@@ -160,9 +160,10 @@ if [[ ! -d "$HOME/.rbenv" ]]; then
     brew_install_or_upgrade 'ruby-build'
 fi
 
-fancy_echo "Upgrading and linking OpenSSL ..."
+fancy_echo "Installing sytem dependencies for Ruby builds ..."
   brew_install_or_upgrade 'openssl'
   brew unlink openssl && brew link openssl --force
+  brew_install_or_upgrade 'libyaml'
 
 ruby_version="$(curl -sSL http://ruby.thoughtbot.com/latest)"
 


### PR DESCRIPTION
I saw this problem while installing Ruby 2.1.4. Installing libyaml first
solved the problem.

https://github.com/sstephenson/ruby-build/wiki#suggested-build-environment
