### PR TITLE
Remove Parity, Watch, Suspenders, and Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ What it sets up
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
 * [NVM] for managing versions of Node.js
-* [Parity] for development, staging, and production parity
 * [Postgres] for storing relational data
 * [Qt] for headless JavaScript testing via Capybara Webkit
-* [Rails] gem for writing web applications
 * [Rbenv] for managing versions of Ruby
 * [Redis] for storing key-value data
 * [Ruby Build] for installing Rubies
@@ -69,17 +67,14 @@ What it sets up
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
 [NVM]: https://github.com/creationix/nvm
-[Parity]: https://github.com/croaky/parity
 [Postgres]: http://www.postgresql.org/
 [Qt]: http://qt-project.org/
-[Rails]: http://rubyonrails.org/
 [Rbenv]: https://github.com/sstephenson/rbenv
 [Redis]: http://redis.io/
 [Ruby Build]: https://github.com/sstephenson/ruby-build
 [Ruby]: https://www.ruby-lang.org/en/
 [The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
 [Tmux]: http://tmux.sourceforge.net/
-[Watch]: http://linux.die.net/man/1/watch
 [Zsh]: http://www.zsh.org/
 
 It should take less than 15 minutes to install (depends on your machine).
@@ -103,10 +98,18 @@ brew install brew-cask
 brew cask install dropbox
 brew cask install google-chrome
 brew cask install rdio
+
+gem install suspenders
+gem install parity
+
+brew_install_or_upgrade 'watch'
 ```
 
-You should write your customizations such that they can be run safely more than
-once. See the `mac` script for examples.
+Write your customizations such that they can be run safely more than once.
+See the `mac` script for examples.
+
+Laptop functions such as `fancy_echo` and `brew_install_or_upgrade`
+can be used in your `~/.laptop.local`.
 
 Credits
 -------

--- a/mac
+++ b/mac
@@ -128,9 +128,6 @@ fancy_echo "Installing ImageMagick, to crop and resize images ..."
 fancy_echo "Installing QT, used by Capybara Webkit for headless Javascript integration testing ..."
   brew_install_or_upgrade 'qt'
 
-fancy_echo "Installing watch, to execute a program periodically and show the output ..."
-  brew_install_or_upgrade 'watch'
-
 fancy_echo "Installing GitHub CLI client ..."
   brew_install_or_upgrade 'gh'
 
@@ -186,12 +183,6 @@ fancy_echo "Installing Bundler to install project-specific Ruby gems ..."
 fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
-
-fancy_echo "Installing Suspenders, thoughtbot's Rails template ..."
-  gem install suspenders --no-document
-
-fancy_echo "Installing Parity, shell commands for development, staging, and production parity ..."
-  gem install parity --no-document
 
 fancy_echo "Installing Heroku CLI for managing Heroku apps and Foreman for managing app processes ..."
   brew_install_or_upgrade 'heroku-toolbelt'


### PR DESCRIPTION
- These are great tools, but not critical.
- Some tools should be re-installed right before their use,
  such as Suspenders.
- Restrict Laptop to more fundamental setup.
- Document how to install these in `~/.laptop.local`.
