### PR TITLE
Use `tree` as customization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Laptop can be run multiple times on the same machine safely. It will upgrade
 already installed packages and install and activate a new version of ruby (if
 one is available).
 
-Make your own customizations
-----------------------------
+Customize in `~/.laptop.local`
+------------------------------
 
-Put your customizations in `~/.laptop.local`. For example, your
-`~/.laptop.local` might look like this:
+Your `~/.laptop.local` is run at the end of the Laptop script.
+Put your customizations there.
+For example:
 
 ```sh
 #!/bin/sh
@@ -101,9 +102,9 @@ brew cask install dropbox
 brew cask install google-chrome
 brew cask install rdio
 
-gem install suspenders
 gem install parity
 
+brew_install_or_upgrade 'tree'
 brew_install_or_upgrade 'watch'
 ```
 


### PR DESCRIPTION
Laptop should be responsible for setting up the compilers, system package
manager, programming language version managers & installers, large system
dependencies such as Postgres, and any critical config for those tools which
is often overlooked but can cause bugs and headaches.

Other useful command-line tools such as `watch` and `tree` are better
installed in individuals' `~/.laptop.local` files.

Add `tree` as a good example for that file.

Try to make `~/.laptop.local` explanation clearer and more prominent by
placing it in a heading.

Remove Suspenders as an example. Right before using Suspenders, it's probably
best to re-install it to get the latest.
