### PR TITLE
Revert `gh` to `hub`

### DIFF
--- a/mac
+++ b/mac
@@ -143,7 +143,7 @@ brew_install_or_upgrade 'tmux'
 brew_install_or_upgrade 'reattach-to-user-namespace'
 brew_install_or_upgrade 'imagemagick'
 brew_install_or_upgrade 'qt'
-brew_install_or_upgrade 'gh'
+brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
 
 brew_install_or_upgrade 'rbenv'


### PR DESCRIPTION
`hub`, like `gh`, is now powered by `go`.

https://github.com/github/hub#2x

Since `gh` is a GitHub CLI, why not use the CLI created by GitHub themselves.

Additionally, `hub` handles `$ git clone thoughtbot/laptop` out of the box.