### PR TITLE
Use Homebrew for Git

### DIFF
--- a/mac
+++ b/mac
@@ -107,6 +107,7 @@ fi
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 
+brew_install_or_upgrade 'git'
 brew_install_or_upgrade 'postgres'
 
 fancy_echo "Restarting Postgres ..."


### PR DESCRIPTION
We previously relied on the version of Git that comes with XCode. The Homebrew
version is easier to upgrade when new versions of Git are released, such as
yesterday's security patch:

https://github.com/blog/1938-git-client-vulnerability-announced
