### PR TITLE
Add brew_tap function

### DIFF
--- a/mac
+++ b/mac
@@ -79,6 +79,18 @@ brew_is_upgradable() {
   ! brew outdated --quiet "$name" >/dev/null
 }
 
+brew_tap() {
+    if brew_tap_is_tapped "$1"; then
+        fancy_echo "Already tapped %s. Skipping ..." "$1"
+    else
+        brew tap $1
+    fi
+}
+
+brew_tap_is_tapped() {
+    brew tap | grep -Fqx $1
+}
+
 brew_expand_alias() {
   brew info "$1" 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'
 }
@@ -192,7 +204,7 @@ fancy_echo "Configuring Bundler ..."
 brew_install_or_upgrade 'heroku-toolbelt'
 
 if ! command -v rcup >/dev/null; then
-  brew tap thoughtbot/formulae
+  brew_tap 'thoughtbot/formulae'
   brew_install_or_upgrade 'rcm'
 fi
 


### PR DESCRIPTION
This prevents the ugly "Warning" messages homebrew output's by default when tapping something that is already tapped. Sourcing this script in my personal set up, I use it as thus:

```
brew_tap 'homebrew/dupes'
brew_tap 'homebrew/versions'
brew_tap 'homebrew/boneyard'
brew_tap 'homebrew/science'
brew_tap 'homebrew/php'
brew_tap 'caskroom/cask'
brew_tap 'caskroom/versions'
brew_tap 'caskroom/fonts'
brew_tap 'thoughtbot/formulae'
```