### PR TITLE
Fix rbenv idempotence

### DIFF
--- a/mac
+++ b/mac
@@ -146,13 +146,11 @@ brew_install_or_upgrade 'qt'
 brew_install_or_upgrade 'gh'
 brew_install_or_upgrade 'node'
 
-if [ ! -d "$HOME/.rbenv" ]; then
-  brew_install_or_upgrade 'rbenv'
-  brew_install_or_upgrade 'ruby-build'
+brew_install_or_upgrade 'rbenv'
+brew_install_or_upgrade 'ruby-build'
 
-  # shellcheck disable=SC2016
-  append_to_zshrc 'eval "$(rbenv init - zsh --no-rehash)"' 1
-fi
+# shellcheck disable=SC2016
+append_to_zshrc 'eval "$(rbenv init - zsh --no-rehash)"' 1
 
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force


### PR DESCRIPTION
The `if` statement causes rbenv to only be installed, never upgraded.

Now that we have `brew_install_or_upgrade`, we can eliminate the `if`
statement.