### PR TITLE
Remove NVM, simplify to `brew install node`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ What it sets up
 * [Homebrew] for managing operating system libraries
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
-* [NVM] for managing versions of Node.js
 * [Postgres] for storing relational data
 * [Qt] for headless JavaScript testing via Capybara Webkit
 * [Rbenv] for managing versions of Ruby
@@ -70,7 +69,6 @@ What it sets up
 [ImageMagick]: http://www.imagemagick.org/
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
-[NVM]: https://github.com/creationix/nvm
 [Postgres]: http://www.postgresql.org/
 [Qt]: http://qt-project.org/
 [Rbenv]: https://github.com/sstephenson/rbenv

--- a/mac
+++ b/mac
@@ -140,22 +140,7 @@ brew_install_or_upgrade 'reattach-to-user-namespace'
 brew_install_or_upgrade 'imagemagick'
 brew_install_or_upgrade 'qt'
 brew_install_or_upgrade 'gh'
-
-node_version="0.10"
-
-brew_install_or_upgrade 'nvm'
-
-# shellcheck disable=SC2016
-append_to_zshrc 'export PATH="$PATH:/usr/local/lib/node_modules"'
-
-# shellcheck disable=SC2016
-append_to_zshrc 'source $(brew --prefix nvm)/nvm.sh' 1
-
-. "$(brew --prefix nvm)/nvm.sh"
-nvm install "$node_version"
-
-fancy_echo "Setting $node_version as the global default nodejs..."
-nvm alias default "$node_version"
+brew_install_or_upgrade 'node'
 
 if [ ! -d "$HOME/.rbenv" ]; then
   brew_install_or_upgrade 'rbenv'


### PR DESCRIPTION
From @derekprior:

> I never used NVM. I just kept my homebrew installed version pinned to
> the version we were using. As a company this is probably totally fine
> because we don't jump back and forth between node projects like we do
> with Ruby projects. Also, there is no "system" node to worry about.

https://github.com/thoughtbot/laptop/pull/341#issuecomment-66179326