### PR TITLE
Default $skip_new_line to 0

### DIFF
--- a/mac
+++ b/mac
@@ -13,7 +13,7 @@ fancy_echo() {
 
 append_to_zshrc() {
   local text="$1" zshrc
-  local skip_new_line="$2"
+  local skip_new_line="${2:-0}"
 
   if [ -w "$HOME/.zshrc.local" ]; then
     zshrc="$HOME/.zshrc.local"


### PR DESCRIPTION
In Bash, `[ "" -eq 1 ]` causes:

  [: : integer expression expected

Resolves #377