### PR TITLE
Install Git, Postgres, Heroku Toolbelt via Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ sh mac 2>&1 | tee ~/laptop.log
 Debugging
 ---------
 
-Your last Laptop run will be saved to `~/laptop.log`. Read through it to see if
-you can debug the issue yourself. If not, copy the lines where the script
-failed into a [new GitHub
-Issue](https://github.com/thoughtbot/laptop/issues/new) for us. Or, attach the
-whole log file as an attachment.
+Your last Laptop run will be saved to `~/laptop.log`.
+Read through it to see if you can debug the issue yourself.
+If not, copy the lines where the script failed into a
+[new GitHub Issue](https://github.com/thoughtbot/laptop/issues/new) for us.
+Or, attach the whole log file as an attachment.
 
 What it sets up
 ---------------
@@ -44,9 +44,9 @@ What it sets up
 * [Bundler] for managing Ruby libraries
 * [Exuberant Ctags] for indexing files for vim tab completion
 * [Foreman] for managing web processes
-* [gh] for interacting with the GitHub API
-* [Heroku Toolbelt] for interacting with the Heroku API
+* [Heroku Toolbelt] via [Parity] for interacting with the Heroku API
 * [Homebrew] for managing operating system libraries
+* [Hub] for interacting with the GitHub API
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
 * [Postgres] for storing relational data
@@ -63,12 +63,13 @@ What it sets up
 [Bundler]: http://bundler.io/
 [Exuberant Ctags]: http://ctags.sourceforge.net/
 [Foreman]: https://github.com/ddollar/foreman
-[gh]: https://github.com/jingweno/gh
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
+[Hub]: https://github.com/github/hub
 [ImageMagick]: http://www.imagemagick.org/
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
+[Parity]: https://github.com/thoughtbot/parity
 [Postgres]: http://www.postgresql.org/
 [Qt]: http://qt-project.org/
 [Rbenv]: https://github.com/sstephenson/rbenv

--- a/mac
+++ b/mac
@@ -80,7 +80,7 @@ brew_is_upgradable() {
 }
 
 brew_tap() {
-  brew tap "$1" 2> /dev/null
+  brew tap "$1" --repair 2> /dev/null
 }
 
 brew_expand_alias() {
@@ -128,11 +128,12 @@ else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi
 
+brew_tap 'thoughtbot/formulae'
+
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 
-brew_install_or_upgrade 'git'
-brew_install_or_upgrade 'postgres'
+brew_install_or_upgrade 'parity'
 brew_launchctl_restart 'postgresql'
 brew_install_or_upgrade 'redis'
 brew_launchctl_restart 'redis'
@@ -175,10 +176,7 @@ fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
 
-brew_install_or_upgrade 'heroku-toolbelt'
-
 if ! command -v rcup >/dev/null; then
-  brew_tap 'thoughtbot/formulae'
   brew_install_or_upgrade 'rcm'
 fi
 


### PR DESCRIPTION
* The Parity Homebrew [package] installs Heroku Toolbelt, Git, Postgres.
* Tap the Homebrew formula first, so it updates with `brew update`.
* Use the [`--repair`] flag to check for dead symlinks
  and relink all valid formulae across taps.
* Update and reformat README.

[package]: https://github.com/thoughtbot/homebrew-formulae/blob/master/Formula/parity.rb
[`--repair`]: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md