### PR TITLE
Install rbenv-gem-rehash

### DIFF
--- a/mac
+++ b/mac
@@ -147,6 +147,7 @@ brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
 
 brew_install_or_upgrade 'rbenv'
+brew_install_or_upgrade 'rbenv-gem-rehash'
 brew_install_or_upgrade 'ruby-build'
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
> Never run rbenv rehash again. This rbenv plugin automatically runs
> `rbenv rehash` every time you install or uninstall a gem.

https://github.com/sstephenson/rbenv-gem-rehash