### PR TITLE
Install Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ What it sets up
 * [Bundler] for managing Ruby libraries
 * [Exuberant Ctags] for indexing files for vim tab completion
 * [Foreman] for managing web processes
-* [hub] for interacting with the GitHub API
-* [Heroku Toolbelt] for interacting with the Heroku API
+* [Hub] for interacting with the GitHub API
+* [Heroku Toolbelt] and [Parity] for interacting with the Heroku API
 * [Homebrew] for managing operating system libraries
 * [ImageMagick] for cropping and resizing images
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
@@ -77,12 +77,13 @@ What it sets up
 [Bundler]: http://bundler.io/
 [Exuberant Ctags]: http://ctags.sourceforge.net/
 [Foreman]: https://github.com/ddollar/foreman
-[hub]: http://hub.github.com/
+[Hub]: http://hub.github.com/
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [ImageMagick]: http://www.imagemagick.org/
 [Node.js]: http://nodejs.org/
 [NPM]: https://www.npmjs.org/
+[Parity]: https://github.com/thoughtbot/parity
 [Postgres]: http://www.postgresql.org/
 [Qt]: http://qt-project.org/
 [Rbenv]: https://github.com/sstephenson/rbenv

--- a/mac
+++ b/mac
@@ -138,6 +138,7 @@ if brew list | grep -Fq brew-cask; then
 fi
 
 fancy_echo "Updating Homebrew formulae ..."
+brew_tap 'thoughtbot/formulae'
 brew update
 
 brew_install_or_upgrade 'zsh'
@@ -155,6 +156,9 @@ brew_install_or_upgrade 'imagemagick'
 brew_install_or_upgrade 'qt'
 brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
+brew_install_or_upgrade 'heroku-toolbelt'
+brew_install_or_upgrade 'parity'
+brew_install_or_upgrade 'rcm'
 
 brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
@@ -188,13 +192,6 @@ gem_install_or_update 'bundler'
 fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
-
-brew_install_or_upgrade 'heroku-toolbelt'
-
-if ! command -v rcup >/dev/null; then
-  brew_tap 'thoughtbot/formulae'
-  brew_install_or_upgrade 'rcm'
-fi
 
 if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1090


### PR DESCRIPTION
* The Parity Homebrew [package] installs Heroku Toolbelt, Git, Postgres
  but it seems nice for documentation purposes to
  keep the Homebrew packages installed for the other dependencies.
* Tap the Homebrew formula first, so it updates with `brew update`.

[package]: https://github.com/thoughtbot/homebrew-formulae/blob/master/Formula/parity.rb