### PR TITLE
fix rbenv init which is added to zshrc

### DIFF
--- a/mac
+++ b/mac
@@ -150,7 +150,7 @@ brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
 
 # shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - zsh --no-rehash)"' 1
+append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
 
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force


### PR DESCRIPTION
The `--no-rehash` parameter should go in front of the shell, not behind. The previous order was resulting in `basename: illegal option -- -` errors for me when using `rbenv shell`.

The correct is also explained in `rbenv help init`

    Usage: eval "$(rbenv init - [--no-rehash] [<shell>])" 