### PR TITLE
Add source comment for every line added by `append_to_zshrc`

### DIFF
--- a/mac
+++ b/mac
@@ -22,10 +22,11 @@ append_to_zshrc() {
   fi
 
   if ! grep -Fqs "$text" "$zshrc"; then
+    local source_comment="# added by thoughtbot/laptop script"
     if [ "$skip_new_line" -eq 1 ]; then
-      printf "%s\n" "$text" >> "$zshrc"
+      printf "%s\n" "$text $source_comment" >> "$zshrc"
     else
-      printf "\n%s\n" "$text" >> "$zshrc"
+      printf "\n%s\n" "$text $source_comment" >> "$zshrc"
     fi
   fi
 }


### PR DESCRIPTION
It's always nice to know where things come from, especially when there's no guarantee that the document of interest is under source control.

The verbosity in `.zshrc` caused by this diff might be a little overbearing, but I figured that a lot of history in the affected config is better than no history at all.

If y'all are interested in source comments, but annoyed by the verbosity, I'm game to work on a more robust solution. Perhaps something where the helper functions `start_source_comment` and `end_source_comment` are available and each are only called once. So something like this:

```sh
# file: mac

# define helper functions

start_source_comment # ensures that the first line of the zshrc has a source comment 

# ...

end_source_comment # ensures that only the last line of the zshrc has a source comment 
```

Let me know what you think! 