### PR TITLE
Add link to thoughtbot/dotfiles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ less mac
 sh mac 2>&1 | tee ~/laptop.log
 ```
 
+Optionally [install thoughtbot's
+dotfiles](https://github.com/thoughtbot/dotfiles#install).
+
 Debugging
 ---------
 


### PR DESCRIPTION
- Add link to thoughtbot/dotfiles in README.md

I'm a big fan of thoughtbot's dotfiles and while installing laptop on a new machine I was, momentarily, confused as to why the shell's theme hadn't updated. I think this adds clarity and direction for further customizing your machine after installing laptop.