### PR TITLE
Fix brew_expand_alias for non-standard packages

### DIFF
--- a/mac
+++ b/mac
@@ -84,7 +84,7 @@ brew_tap() {
 }
 
 brew_expand_alias() {
-  brew info "$1" 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'
+  brew info $1 2>/dev/null | head -1 | awk '{gsub(/.*\//, ""); gsub(/:/, ""); print $1}'
 }
 
 brew_launchctl_restart() {

--- a/mac
+++ b/mac
@@ -84,7 +84,7 @@ brew_tap() {
 }
 
 brew_expand_alias() {
-  brew info $1 2>/dev/null | head -1 | awk '{gsub(/.*\//, ""); gsub(/:/, ""); print $1}'
+  brew info "$1" 2>/dev/null | head -1 | awk '{gsub(/.*\//, ""); gsub(/:/, ""); print $1}'
 }
 
 brew_launchctl_restart() {


### PR DESCRIPTION
For example:

```brew info brew-cask 2>/dev/null | head -1 | awk '{gsub(/:/, ""); print $1}'```
caskroom/cask/brew-cask

```brew info brew-cask 2>/dev/null | head -1 | awk '{gsub(/.*\//, ""); gsub(/:/, ""); print $1}'```
brew-cask

-----------------------------

```brew list -1``` only has the shorter name listed so it will try to re-install packages that are already installed