### PR TITLE
Finish dotfile installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ versions are welcome.
 Install
 -------
 
+Optionally, clone your dotfiles before installing laptop. [install thoughtbot/dotfiles][dotfiles]
+
+```sh
+git clone git://github.com/thoughtbot/dotfiles.git ~/dotfiles
+```
+
+[dotfiles]: https://github.com/thoughtbot/dotfiles#install
+
 Download, review, then execute the script:
 
 ```sh
@@ -28,10 +36,6 @@ curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/ma
 less mac
 sh mac 2>&1 | tee ~/laptop.log
 ```
-
-Optionally, [install thoughtbot/dotfiles][dotfiles].
-
-[dotfiles]: https://github.com/thoughtbot/dotfiles#install
 
 Debugging
 ---------

--- a/mac
+++ b/mac
@@ -183,6 +183,11 @@ if ! command -v rcup >/dev/null; then
   brew_install_or_upgrade 'rcm'
 fi
 
+if [ -d "$HOME/dotfiles" ]; then
+  fancy_echo "Dotfiles installed, running rcup ..."
+  env RCRC="$HOME/dotfiles/rcrc" rcup
+fi
+
 if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"
 fi


### PR DESCRIPTION
This helps prevent the chicken/egg:

* We need dotfiles to have a `laptop.local` file.
* We need rcm to install dotfiles.
* Laptop installs rcm.

Related to: thoughtbot/dotfiles#407