### PR TITLE
Install docker and create a default virtualbox vm

### DIFF
--- a/mac
+++ b/mac
@@ -150,6 +150,11 @@ brew_install_or_upgrade 'node'
 brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
 
+brew_install_or_upgrade 'caskroom/cask/virtualbox'
+brew_install_or_upgrade 'docker'
+brew_install_or_upgrade 'docker-machine'
+docker-machine create --driver virtualbox default
+
 # shellcheck disable=SC2016
 append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
 


### PR DESCRIPTION
## Problem:

Docker has proven to be a useful solution for setting up consistent development environments.

For newcomers, Docker installation and first-time usage can be intimidating.  This cuts back on the number of people willing to use Docker in their projects, and makes projects that use Docker (such as the Playbook) less accessible to non-technical contributors.

## Solution:

- Install Docker through homebrew.
- Install virualbox (a dependency) through homebrew cask.
- Create a default Docker vm according to instructions at
  https://docs.docker.com/installation/mac/#from-your-shell

## Next steps:

In order to use the default vm, several environment variables need to be set.

According to `docker-machine env default`:

```bash
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.99.100:2376"
export DOCKER_CERT_PATH="/Users/grayson/.docker/machine/machines/default"
export DOCKER_MACHINE_NAME="default"
# Run this command to configure your shell:
# eval "$(docker-machine env default)"
```

The easiest way to set this up for everyone is to add a line to thoughtbot's dotfiles:

```bash
eval "$(docker-machine env default)"
```