### PR TITLE
Prefer `ruby-install` over `ruby-build`

### DIFF
--- a/mac
+++ b/mac
@@ -148,7 +148,7 @@ brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
 
 brew_install_or_upgrade 'rbenv'
-brew_install_or_upgrade 'ruby-build'
+brew_install_or_upgrade 'ruby-install'
 
 # shellcheck disable=SC2016
 append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1


### PR DESCRIPTION
Based on discussion at https://trello.com/c/0rlBCEms/411-ruby-install
Co-dependent on https://github.com/thoughtbot/dotfiles/pull/445

## Problem:

The two main tools for installing ruby, `ruby-build` and `ruby-install`,
both have drawbacks.

- `ruby-build` requires an update in order to install new versions of
  ruby.
- `ruby-install` requires command-line arguments in order to install
  rubies in an rbenv-compatible way.

## Solution:

Add a wrapper around `ruby-install` that takes care of the command line
arguments for us. This lets us install new ruby versions with the
command:

```
rinstall 2.2.2
```

where 2.2.2 is the version number.

The tool never needs to be updated, and installs into the directory that
rbenv expects. As a bonus, it will automatically install bundler for you
and attempt to `bundle install` for the current directory.