### PR TITLE
Migrate to built-in Homebrew-Cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ For example:
 ```sh
 #!/bin/sh
 
-brew_tap 'caskroom/cask'
-brew_install_or_upgrade 'brew-cask'
-
 brew cask install dropbox
 brew cask install google-chrome
 brew cask install rdio

--- a/mac
+++ b/mac
@@ -132,6 +132,11 @@ else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi
 
+if brew list | grep -Fq brew-cask; then
+  fancy_echo "Uninstalling old Homebrew-Cask ..."
+  brew uninstall --force brew-cask
+fi
+
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 


### PR DESCRIPTION
> Homebrew-Cask will now be kept up to date together with Homebrew

> If you haven’t yet,
> run `brew uninstall --force brew-cask; brew update`
> to switch to the new system.

https://github.com/caskroom/homebrew-cask/commit/e83c0099aaac27ab440b28bbca2ba1e0ec1a4d04

> To start using Homebrew-Cask, you just need Homebrew installed.

https://github.com/caskroom/homebrew-cask/commit/0d290b15e894c8db387f77e2586223368a04fea8