### PR TITLE
Re-organize the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,24 +106,21 @@ For example:
 ```sh
 #!/bin/sh
 
-brew_tap 'caskroom/cask'
-brew_install_or_upgrade 'brew-cask'
-
 brew cask install dropbox
 brew cask install google-chrome
-brew cask install rdio
 
 gem_install_or_update 'parity'
 
-brew_install_or_upgrade 'tree'
-brew_install_or_upgrade 'watch'
+brew install tree
+brew install watch
 ```
 
 Write your customizations such that they can be run safely more than once.
 See the `mac` script for examples.
 
 Laptop functions such as `fancy_echo`,
-`brew_install_or_upgrade`, and
+`brew_tap`,
+`brew_launchctl_restart`, and
 `gem_install_or_update`
 can be used in your `~/.laptop.local`.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ It should take less than 15 minutes to install (depends on your machine).
 Customize in `~/.laptop.local`
 ------------------------------
 
-Your `~/.laptop.local` is run at the end of the Laptop script.
+Your `~/.laptop.local` is run near the end of the Laptop script.
 Put your customizations there.
 For example:
 

--- a/mac
+++ b/mac
@@ -54,6 +54,20 @@ case "$SHELL" in
     ;;
 esac
 
+brew_install_or_upgrade() {
+  fancy_echo "brew_install_or_upgrade is deprecated. Use brew install instead."
+}
+
+brew_is_installed() {
+  fancy_echo "brew_is_installed is deprecated."
+  return 1
+}
+
+brew_is_upgradable() {
+  fancy_echo "brew_is_upgradable is deprecated."
+  return 1
+}
+
 brew_tap() {
   brew tap "$1" 2> /dev/null
 }
@@ -105,8 +119,11 @@ else
 fi
 
 fancy_echo "Updating Homebrew formulas ..."
+brew_tap 'thoughtbot/formulae'
 brew update
 
+fancy_echo "Upgrading Homebrew formulas ..."
+brew upgrade
 
 brew install zsh
 brew install git
@@ -160,7 +177,6 @@ fancy_echo "Configuring Bundler ..."
 brew install heroku-toolbelt
 
 if ! command -v rcup >/dev/null; then
-  brew_tap 'thoughtbot/formulae'
   brew install rcm
 fi
 
@@ -168,3 +184,7 @@ if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1090
   . "$HOME/.laptop.local"
 fi
+
+fancy_echo "Cleaning up old Homebrew formulas ..."
+brew cleanup
+brew cask cleanup

--- a/mac
+++ b/mac
@@ -82,7 +82,6 @@ brew_launchctl_restart() {
   local domain="homebrew.mxcl.$name"
   local plist="$domain.plist"
 
-  fancy_echo "Restarting %s ..." "$1"
   mkdir -p "$HOME/Library/LaunchAgents"
   ln -sfv "/usr/local/opt/$name/$plist" "$HOME/Library/LaunchAgents"
 
@@ -94,10 +93,8 @@ brew_launchctl_restart() {
 
 gem_install_or_update() {
   if gem list "$1" --installed > /dev/null; then
-    fancy_echo "Updating %s ..." "$1"
     gem update "$@"
   else
-    fancy_echo "Installing %s ..." "$1"
     gem install "$@"
     rbenv rehash
   fi
@@ -114,50 +111,50 @@ if ! command -v brew >/dev/null; then
     append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
 
     export PATH="/usr/local/bin:$PATH"
-else
-  fancy_echo "Homebrew already installed. Skipping ..."
 fi
 
 fancy_echo "Updating Homebrew formulas ..."
 brew_tap 'thoughtbot/formulae'
 brew update
 
-fancy_echo "Upgrading Homebrew formulas ..."
+fancy_echo "Installing Homebrew packages ..."
 brew upgrade
-
-brew install zsh
-brew install git
-brew install postgres
-brew_launchctl_restart 'postgresql'
-brew install redis
-brew_launchctl_restart 'redis'
-brew install the_silver_searcher
-brew install vim
 brew install ctags
-brew install tmux
-brew install reattach-to-user-namespace
-brew install imagemagick
-brew install qt
+brew install git
+brew install heroku-toolbelt
 brew install hub
-brew install node
-
-brew install rbenv
-brew install ruby-build
-
-# shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
-
-brew install openssl
-brew unlink openssl && brew link openssl --force
+brew install imagemagick
 brew install libyaml
+brew install node
+brew install openssl
+brew install postgres
+brew install qt
+brew install rbenv
+brew install rcm
+brew install reattach-to-user-namespace
+brew install redis
+brew install ruby-build
+brew install the_silver_searcher
+brew install tmux
+brew install vim
+brew install zsh
 
+fancy_echo "Restarting services ..."
+brew_launchctl_restart 'postgresql'
+brew_launchctl_restart 'redis'
+
+fancy_echo "Relinking OpenSSL ..."
+brew unlink openssl && brew link openssl --force
+
+fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {
   rbenv install -l | grep -v - | tail -1 | sed -e 's/^ *//'
 }
 
-ruby_version="$(find_latest_ruby)"
-
+# shellcheck disable=SC2016
+append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
 eval "$(rbenv init -)"
+ruby_version="$(find_latest_ruby)"
 
 if ! rbenv versions | grep -Fq "$ruby_version"; then
   rbenv install -s "$ruby_version"
@@ -165,22 +162,13 @@ fi
 
 rbenv global "$ruby_version"
 rbenv shell "$ruby_version"
-
 gem update --system
-
 gem_install_or_update 'bundler'
-
-fancy_echo "Configuring Bundler ..."
-  number_of_cores=$(sysctl -n hw.ncpu)
-  bundle config --global jobs $((number_of_cores - 1))
-
-brew install heroku-toolbelt
-
-if ! command -v rcup >/dev/null; then
-  brew install rcm
-fi
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
 
 if [ -f "$HOME/.laptop.local" ]; then
+  fancy_echo "Running your customizations from ~/.laptop.local ..."
   # shellcheck disable=SC1090
   . "$HOME/.laptop.local"
 fi

--- a/mac
+++ b/mac
@@ -54,34 +54,6 @@ case "$SHELL" in
     ;;
 esac
 
-brew_install_or_upgrade() {
-  if brew_is_installed "$1"; then
-    if brew_is_upgradable "$1"; then
-      fancy_echo "Upgrading %s ..." "$1"
-      brew upgrade "$@"
-    else
-      fancy_echo "Already using the latest version of %s. Skipping ..." "$1"
-    fi
-  else
-    fancy_echo "Installing %s ..." "$1"
-    brew install "$@"
-  fi
-}
-
-brew_is_installed() {
-  local name
-  name="$(brew_expand_alias "$1")"
-
-  brew list -1 | grep -Fqx "$name"
-}
-
-brew_is_upgradable() {
-  local name
-  name="$(brew_expand_alias "$1")"
-
-  ! brew outdated --quiet "$name" >/dev/null
-}
-
 brew_tap() {
   brew tap "$1" 2> /dev/null
 }
@@ -135,31 +107,32 @@ fi
 fancy_echo "Updating Homebrew formulas ..."
 brew update
 
-brew_install_or_upgrade 'zsh'
-brew_install_or_upgrade 'git'
-brew_install_or_upgrade 'postgres'
-brew_launchctl_restart 'postgresql'
-brew_install_or_upgrade 'redis'
-brew_launchctl_restart 'redis'
-brew_install_or_upgrade 'the_silver_searcher'
-brew_install_or_upgrade 'vim'
-brew_install_or_upgrade 'ctags'
-brew_install_or_upgrade 'tmux'
-brew_install_or_upgrade 'reattach-to-user-namespace'
-brew_install_or_upgrade 'imagemagick'
-brew_install_or_upgrade 'qt'
-brew_install_or_upgrade 'hub'
-brew_install_or_upgrade 'node'
 
-brew_install_or_upgrade 'rbenv'
-brew_install_or_upgrade 'ruby-build'
+brew install zsh
+brew install git
+brew install postgres
+brew_launchctl_restart 'postgresql'
+brew install redis
+brew_launchctl_restart 'redis'
+brew install the_silver_searcher
+brew install vim
+brew install ctags
+brew install tmux
+brew install reattach-to-user-namespace
+brew install imagemagick
+brew install qt
+brew install hub
+brew install node
+
+brew install rbenv
+brew install ruby-build
 
 # shellcheck disable=SC2016
 append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
 
-brew_install_or_upgrade 'openssl'
+brew install openssl
 brew unlink openssl && brew link openssl --force
-brew_install_or_upgrade 'libyaml'
+brew install libyaml
 
 find_latest_ruby() {
   rbenv install -l | grep -v - | tail -1 | sed -e 's/^ *//'
@@ -184,11 +157,11 @@ fancy_echo "Configuring Bundler ..."
   number_of_cores=$(sysctl -n hw.ncpu)
   bundle config --global jobs $((number_of_cores - 1))
 
-brew_install_or_upgrade 'heroku-toolbelt'
+brew install heroku-toolbelt
 
 if ! command -v rcup >/dev/null; then
   brew_tap 'thoughtbot/formulae'
-  brew_install_or_upgrade 'rcm'
+  brew install rcm
 fi
 
 if [ -f "$HOME/.laptop.local" ]; then

--- a/mac
+++ b/mac
@@ -155,7 +155,7 @@ brew_install_or_upgrade 'rbenv'
 brew_install_or_upgrade 'ruby-build'
 
 # shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
+append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
 
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force
@@ -167,7 +167,7 @@ find_latest_ruby() {
 
 ruby_version="$(find_latest_ruby)"
 
-eval "$(rbenv init - zsh)"
+eval "$(rbenv init -)"
 
 if ! rbenv versions | grep -Fq "$ruby_version"; then
   rbenv install -s "$ruby_version"


### PR DESCRIPTION
This is branched off `upgrade-cleanup-alternative`, only to be merged if we decide to merge https://github.com/thoughtbot/laptop/pull/426.

Group related lines together under one printed header:

* "Installing Homebrew packages ..."
* "Restarting services ..."
* "Relinking OpenSSL ..."
* "Configuring Ruby ..."
* "Running your customizations from ~/.laptop.local ..."
* "Cleaning up old Homebrew formulas ..."

To make that work in the desired way,
print less noise in the custom functions.