### PR TITLE
Check for dead symlinks, relink valid formulae

### DIFF
--- a/mac
+++ b/mac
@@ -79,7 +79,7 @@ brew_is_upgradable() {
 }
 
 brew_tap() {
-  brew tap "$1" 2> /dev/null
+  brew tap "$1" --repair 2> /dev/null
 }
 
 brew_expand_alias() {


### PR DESCRIPTION
Use the [`--repair`] flag to check for dead symlinks
and relink all valid formulae across taps.

[`--repair`]: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md