### PR TITLE
Revert "Clean up old Homebrew formulas after run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ It should take less than 15 minutes to install (depends on your machine).
 Customize in `~/.laptop.local`
 ------------------------------
 
-Your `~/.laptop.local` is run near the end of the Laptop script.
+Your `~/.laptop.local` is run at the end of the Laptop script.
 Put your customizations there.
 For example:
 
@@ -141,6 +141,10 @@ For example:
 brew_install_or_upgrade 'go'
 brew_install_or_upgrade 'ngrok'
 brew_install_or_upgrade 'watch'
+
+fancy_echo "Cleaning up old Homebrew formulae ..."
+brew cleanup
+brew cask cleanup
 
 if [ -r "$HOME/.rcrc" ]; then
   fancy_echo "Updating dotfiles ..."

--- a/mac
+++ b/mac
@@ -140,6 +140,7 @@ fi
 
 fancy_echo "Updating Homebrew formulae ..."
 brew_tap 'thoughtbot/formulae'
+
 brew update
 
 fancy_echo "Updating Unix tools ..."
@@ -205,7 +206,3 @@ if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1090
   . "$HOME/.laptop.local"
 fi
-
-fancy_echo "Cleaning up old Homebrew formulae ..."
-brew cleanup
-brew cask cleanup


### PR DESCRIPTION
This reverts commit ef7408d6a150bb06a164ff4e9dfd6fd09ded367a.

* `brew cleanup` removes Postgres.
* Migrating data in Postgres from old to new versions relies on
  the previous version of Postgres to run `pg_upgrade`.
* Laptop shouldn't lose users' Postgres data.
* Those who don't mind starting their new Postgres databases
  from scratch can `brew cleanup` in `~/.laptop.local`.