### PR TITLE
Set login shell to brew's zsh when available

### DIFF
--- a/mac
+++ b/mac
@@ -60,7 +60,12 @@ case "$SHELL" in
   */zsh) : ;;
   *)
     fancy_echo "Changing your shell to zsh ..."
-      chsh -s "$(which zsh)"
+      shell_path="$(which zsh)"
+      if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
+        fancy_echo "Adding '$shell_path' to /etc/shells"
+        sudo bash -c "echo $shell_path >> /etc/shells"
+      fi
+      chsh -s "$shell_path"
     ;;
 esac
 

--- a/mac
+++ b/mac
@@ -63,7 +63,7 @@ update_shell() {
   fancy_echo "Changing your shell to zsh ..."
   if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
     fancy_echo "Adding '$shell_path' to /etc/shells"
-    sudo bash -c "echo $shell_path >> /etc/shells"
+    sudo sh -c "echo $shell_path >> /etc/shells"
   fi
   chsh -s "$shell_path"
 }

--- a/mac
+++ b/mac
@@ -56,16 +56,26 @@ else
   sudo chown -R "$(whoami)":admin /usr/local
 fi
 
+update_shell() {
+  local shell_path;
+  shell_path="$(which zsh)"
+
+  fancy_echo "Changing your shell to zsh ..."
+  if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
+    fancy_echo "Adding '$shell_path' to /etc/shells"
+    sudo bash -c "echo $shell_path >> /etc/shells"
+  fi
+  chsh -s "$shell_path"
+}
+
 case "$SHELL" in
-  */zsh) : ;;
+  */zsh)
+    if [ "$(which zsh)" != '/bin/zsh' ] ; then
+      update_shell
+    fi
+    ;;
   *)
-    fancy_echo "Changing your shell to zsh ..."
-      shell_path="$(which zsh)"
-      if ! grep "$shell_path" /etc/shells > /dev/null 2>&1 ; then
-        fancy_echo "Adding '$shell_path' to /etc/shells"
-        sudo bash -c "echo $shell_path >> /etc/shells"
-      fi
-      chsh -s "$shell_path"
+    update_shell
     ;;
 esac
 


### PR DESCRIPTION
Currently zsh is being installed and kept up to date by the laptop script. 
But it's a toss-up whether brew's version will be used, and even when it'll get chosen some manual changes will have to be done on a newly installed El Capitan machine (only tested on El Capitan) for it to be set. This since it's not available in `/etc/shells`

After applying this change this is what'll be done on every run of the mac script:
- Check what the current shell is
- If the current shell is zsh
  1. Check if `which zsh` isn't `/bin/zsh` (the one shipped by Apple) 
  2. If a "non-standard" zsh is available set the login shell to that one
- Current shell is not zsh
  1. Set to whichever zsh is available
