### PR TITLE
Don't link OpenSSL

### DIFF
--- a/mac
+++ b/mac
@@ -147,7 +147,6 @@ fancy_echo "Updating Unix tools ..."
 brew_install_or_upgrade 'ctags'
 brew_install_or_upgrade 'git'
 brew_install_or_upgrade 'openssl'
-brew unlink openssl && brew link openssl --force
 brew_install_or_upgrade 'rcm'
 brew_install_or_upgrade 'reattach-to-user-namespace'
 brew_install_or_upgrade 'the_silver_searcher'
@@ -191,7 +190,7 @@ append_to_zshrc 'eval "$(rbenv init - --no-rehash)"' 1
 eval "$(rbenv init -)"
 
 if ! rbenv versions | grep -Fq "$ruby_version"; then
-  rbenv install -s "$ruby_version"
+  RUBY_CONFIGURE_OPTS=--with-openssl-dir=/usr/local/opt/openssl rbenv install -s "$ruby_version"
 fi
 
 rbenv global "$ruby_version"


### PR DESCRIPTION
From @mikemcquaid:

> On 10.11 the OpenSSL headers are removed but library remains. Given
> Clang's default paths this means things will use the Homebrew headers
> but link against the system libraries. At best, it's insecure. At
> worst, it'll cause random, hard-to-debug runtime failures.

https://github.com/thoughtbot/laptop/pull/403/files#r41858641
https://github.com/thoughtbot/laptop/issues/401#issuecomment-114518831