### PR TITLE
env `sh` rather than `/bin/sh`, wider compatibility

### DIFF
--- a/mac
+++ b/mac
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Welcome to the thoughtbot laptop script!
 # Be prepared to turn your laptop (or desktop, no haters here)


### PR DESCRIPTION
It is better noted to use the `env` for discovering `sh` or `bash` as some users may have already removed or deployed a system with changes specified in their image. This was discovered when trying to run the script against our default system images which were heavily modified by previous tech support analysts.