### PR TITLE
Remove rbenv rehash when install gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ What it sets up
 * [Node.js] and [NPM], for running apps and installing JavaScript packages
 * [Postgres] for storing relational data
 * [Qt] for headless JavaScript testing via Capybara Webkit
-* [Rbenv] for managing versions of Ruby
+* [RVM] for managing versions of Ruby
 * [RCM] for managing company and personal dotfiles
 * [Redis] for storing key-value data
 * [Ruby Build] for installing Rubies
@@ -85,7 +85,7 @@ What it sets up
 [NPM]: https://www.npmjs.org/
 [Postgres]: http://www.postgresql.org/
 [Qt]: http://qt-project.org/
-[Rbenv]: https://github.com/sstephenson/rbenv
+[RVM]: https://rvm.io/
 [RCM]: https://github.com/thoughtbot/rcm
 [Redis]: http://redis.io/
 [Ruby Build]: https://github.com/sstephenson/ruby-build

--- a/mac
+++ b/mac
@@ -147,28 +147,15 @@ brew_install_or_upgrade 'qt'
 brew_install_or_upgrade 'hub'
 brew_install_or_upgrade 'node'
 
-brew_install_or_upgrade 'rbenv'
-brew_install_or_upgrade 'ruby-build'
-
-# shellcheck disable=SC2016
-append_to_zshrc 'eval "$(rbenv init - --no-rehash zsh)"' 1
-
 brew_install_or_upgrade 'openssl'
 brew unlink openssl && brew link openssl --force
 brew_install_or_upgrade 'libyaml'
 
 ruby_version="$(curl -sSL http://ruby.thoughtbot.com/latest)"
 
-eval "$(rbenv init - zsh)"
+\curl -L https://get.rvm.io | bash -s stable
 
-if ! rbenv versions | grep -Fq "$ruby_version"; then
-  rbenv install -s "$ruby_version"
-fi
-
-rbenv global "$ruby_version"
-rbenv shell "$ruby_version"
-
-gem update --system
+rvm use ruby --install --default
 
 gem_install_or_update 'bundler'
 
@@ -182,6 +169,8 @@ if ! command -v rcup >/dev/null; then
   brew_tap 'thoughtbot/formulae'
   brew_install_or_upgrade 'rcm'
 fi
+
+gem install rails --no-ri --no-rdoc
 
 if [ -f "$HOME/.laptop.local" ]; then
   . "$HOME/.laptop.local"

--- a/mac
+++ b/mac
@@ -109,7 +109,6 @@ gem_install_or_update() {
   else
     fancy_echo "Installing %s ..." "$1"
     gem install "$@"
-    rbenv rehash
   fi
 }
 


### PR DESCRIPTION
Remove `rbenv rehash` when install gem.
Replace `Rbenv to RVM` on `README.md` file.