### PR TITLE
Install Qt 5 instead of Qt 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
-language: sh
+language: bash
 
-before_script:
-  - wget "http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_0.3.7-5_amd64.deb"
-  - sudo dpkg -i "shellcheck_0.3.7-5_amd64.deb"
+# Use container-based infrastructure for quicker build start-up
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - debian-sid # Get shellcheck from the Debian repo
+    packages:
+    - shellcheck
 
 script:
-  - shellcheck mac
+  - shellcheck mac -e SC2039
+
+matrix:
+  fast_finish: true
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Image tools:
 
 Testing tools:
 
-* [Qt] for headless JavaScript testing via Capybara Webkit
+* [Qt 5] for headless JavaScript testing via [Capybara Webkit]
 
-[Qt]: http://qt-project.org/
+[Qt 5]: http://qt-project.org/
+[Capybara Webkit]: https://github.com/thoughtbot/capybara-webkit
 
 Programming languages and configuration:
 

--- a/mac
+++ b/mac
@@ -136,7 +136,7 @@ brew "hub"
 brew "imagemagick"
 
 # Testing
-brew "qt"
+brew "qt@5.5"
 
 # Programming languages
 brew "libyaml" # should come after openssl
@@ -148,6 +148,9 @@ brew "ruby-build"
 brew "postgres", restart_service: true
 brew "redis", restart_service: true
 EOF
+
+fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
+brew link --force qt@5.5
 
 fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {

--- a/mac
+++ b/mac
@@ -150,6 +150,7 @@ brew "redis", restart_service: true
 EOF
 
 fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
+brew unlink qt@5.5
 brew link --force qt@5.5
 
 fancy_echo "Configuring Ruby ..."


### PR DESCRIPTION
We install Qt because it is a dependency of Capybara Webkit.

> Qt 4 is several years old and contains a version of WebKit with many
> serious defects. Support for Qt 4 will be dropped in any future
> feature releases and is not supported by the capybara-webkit team.

https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit
