### PR TITLE
Use Homebrew path for zsh conditional

### DIFF
--- a/mac
+++ b/mac
@@ -72,7 +72,7 @@ update_shell() {
 
 case "$SHELL" in
   */zsh)
-    if [ "$(which zsh)" != '/bin/zsh' ] ; then
+    if [ "$(which zsh)" != '/usr/local/bin/zsh' ] ; then
       update_shell
     fi
     ;;


### PR DESCRIPTION
* We install zsh via Homebrew in the Laptop script.
* Checking for a different path via `which zsh`
  caused the user to have to type their password every script run
  to allow for `chsh` to run.