### PR TITLE
Install Heroku CLI instead of toolbelt

### DIFF
--- a/mac
+++ b/mac
@@ -127,7 +127,7 @@ brew "watchman"
 brew "zsh"
 
 # Heroku
-brew "heroku-toolbelt"
+brew "heroku"
 brew "parity"
 
 # GitHub


### PR DESCRIPTION
Heroku Toolbelt has been replaced, or perhaps just renamed to, Heroku
CLI. It is installed with `brew install heroku`. See:
https://devcenter.heroku.com/articles/heroku-cli#macos