### PR TITLE
Update heroku binary symlink in PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ Unix tools:
 
 Heroku tools:
 
-* [Heroku Toolbelt] and [Parity] for interacting with the Heroku API
+* [Heroku CLI] and [Parity] for interacting with the Heroku API
 
-[Heroku Toolbelt]: https://toolbelt.heroku.com/
+[Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli
 [Parity]: https://github.com/thoughtbot/parity
 
 GitHub tools:

--- a/mac
+++ b/mac
@@ -155,6 +155,10 @@ fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
 brew unlink qt@5.5
 brew link --force qt@5.5
 
+fancy_echo "Update heroku binary..."
+brew unlink heroku
+brew link --force heroku
+
 fancy_echo "Configuring Ruby ..."
 find_latest_ruby() {
   rbenv install -l | grep -v - | tail -1 | sed -e 's/^ *//'


### PR DESCRIPTION
For users running the Laptop script
who once had `heroku-toolbelt` installed,
it's possible their `PATH` may be out of date.

Use a similar pattern for updating the link to the `heroku` binary
as we used when migrating `qmake` for `qt5.5` from `qt`.

Also, update documentation.

Related: 3b7845b849830033e87617b470d8dd64c925e732