### PR TITLE
Use universal-ctags

### DIFF
--- a/mac
+++ b/mac
@@ -113,9 +113,10 @@ brew update
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
+tap "universal-ctags/universal-ctags"
 
 # Unix
-brew "ctags"
+brew "universal-ctags", args: ["HEAD"]
 brew "git"
 brew "openssl"
 brew "rcm"


### PR DESCRIPTION
Universal ctags is a maintained and improved fork of
exuberant ctags. It adds many things, including better
ruby ctag support, and new supported languages.

https://github.com/universal-ctags/ctags