### PR TITLE
Restart services only when necessary

### DIFF
--- a/mac
+++ b/mac
@@ -147,8 +147,8 @@ brew "ruby-build"
 brew "yarn"
 
 # Databases
-brew "postgres", restart_service: true
-brew "redis", restart_service: true
+brew "postgres", restart_service: :changed
+brew "redis", restart_service: :changed
 EOF
 
 fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."


### PR DESCRIPTION
The Brewfile supports restarting the service only when there's a change
to that service. See [docs][1].

This will provide a marginal speedup when re-running the script.

[1]: https://github.com/Homebrew/homebrew-bundle#restarting-services