### PR TITLE
Skip install of Qt 5.5 if Xcode not installed

### DIFF
--- a/mac
+++ b/mac
@@ -138,7 +138,7 @@ brew "hub"
 brew "imagemagick"
 
 # Testing
-brew "qt@5.5"
+brew "qt@5.5" if MacOS::Xcode.installed?
 
 # Programming languages and package managers
 brew "libyaml" # should come after openssl
@@ -152,9 +152,11 @@ brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
 
-fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
-brew unlink qt@5.5
-brew link --force qt@5.5
+if brew list | grep --silent "qt@5.5"; then
+  fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
+  brew unlink qt@5.5
+  brew link --force qt@5.5
+fi
 
 fancy_echo "Update heroku binary..."
 brew unlink heroku


### PR DESCRIPTION
While trying to run laptop on a new machine, I got the following error:

> A full installation of Xcode.app is required to compile this software.
> Installing just the Command Line Tools is not sufficient.

To truly fix this, we'd need to script the installation of Xcode, which
is beyond my skills at the moment. For now, I use a conditional in the
generated `Brewfile` to skip if Xcode is not installed.