### PR TITLE
Adding a '--force' since there's sometimes a broken homebrew update.

### DIFF
--- a/mac
+++ b/mac
@@ -109,7 +109,7 @@ if brew list | grep -Fq brew-cask; then
 fi
 
 fancy_echo "Updating Homebrew formulae ..."
-brew update --force # bug in Homebrew when even after updating, requests and update
+brew update --force # bug in Homebrew when even after updating, requests an update
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"

--- a/mac
+++ b/mac
@@ -109,7 +109,7 @@ if brew list | grep -Fq brew-cask; then
 fi
 
 fancy_echo "Updating Homebrew formulae ..."
-brew update
+brew update --force # bug in Homebrew when even after updating, requests and update
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"


### PR DESCRIPTION
See https://github.com/Homebrew/brew/issues/1151 

`brew update --force` will prevent stalling in the script. Until the issue above is resolved, it could pop up for someone trapped in a 'please update'-'already updated' loop.