### PR TITLE
Allow specific asdf language versions as optional arg

### DIFF
--- a/mac
+++ b/mac
@@ -184,7 +184,7 @@ install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list-all "$language" | tail -1)"
+  version="${2:-$(asdf list-all "$language" | tail -1)}"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"


### PR DESCRIPTION
Some `asdf` plugins have architecture specific versions at the tail of `list-all`, unlike Ruby & Node, which have the latest at the end.  Allow optional 2nd argument to `install_asdf_language()` to permit hardcoding version numbers.

e.g. `asdf list-all golang | tail -1` yields "1.8.linux-amd64", not "1.8.3"