### PR TITLE
Add script to setup Linux laptops, again.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Laptop
 ======
 
-Laptop is a script to set up an macOS laptop for web and mobile development.
+Laptop is a script to set up an macOS / linux laptop for web and mobile development.
 
 It can be run multiple times on the same machine safely.
 It installs, upgrades, or skips packages
@@ -16,6 +16,7 @@ We support:
 * macOS Yosemite (10.10)
 * macOS El Capitan (10.11)
 * macOS Sierra (10.12)
+* linux Debian / Ubuntu based distros
 
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.
@@ -23,22 +24,25 @@ Bug reports for older versions are welcome.
 Install
 -------
 
-Download the script:
+Download the appropiate script:
 
 ```sh
 curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/mac
+curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/master/linux
 ```
 
 Review the script (avoid running scripts you haven't read!):
 
 ```sh
-less mac
+cat mac
+cat linux
 ```
 
 Execute the downloaded script:
 
 ```sh
 sh mac 2>&1 | tee ~/laptop.log
+bash linux 2>&1 | tee ~/laptop.log
 ```
 
 Optionally, review the log:
@@ -63,11 +67,13 @@ Or, attach the whole log file as an attachment.
 What it sets up
 ---------------
 
-macOS tools:
+Package manager:
 
-* [Homebrew] for managing operating system libraries.
+* [Homebrew] for macOS operating system libraries or
+* [Linuxbrew] for linux operating system libraries
 
 [Homebrew]: http://brew.sh/
+[Linuxbrew]: http://linuxbrew.sh/
 
 Unix tools:
 

--- a/linux
+++ b/linux
@@ -1,15 +1,14 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# Turn your laptop into an awesome development machine.
+# Usage: $ bash linux 2>&1 | tee ~/setup.log
 
-# Turn your laptop into an awesome development machine, to get logs do
-# sh linux 2>&1 | tee ~/setup.log
-
-set -o xtrace  # aka 'set -x' to trace what gets executed
+#set -o xtrace  # aka 'set -x' to trace what gets executed ... for debugging
 set -o errexit # aka 'set -e' to exit when command fails
 # shellcheck disable=SC2154
-#trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 
-echo "create some helper functions ..."
-#######################################
+echo "### create some helper functions ..."
+##########################################
 append_to_zshrc() {
   local text="$1" zshrc
   local skip_new_line="${2:-0}"
@@ -27,8 +26,6 @@ append_to_zshrc() {
       printf "\n%s\n" "$text" >> "$zshrc"
     fi
   fi
-
-  source "$zshrc"
 }
 
 install_asdf_plugin() {
@@ -59,24 +56,26 @@ gem_install_or_update() {
   fi
 }
 
-echo "create lolca bin directory ..."
-#####################################
-if [ ! -d "$HOME/.bin/" ]; then
-  mkdir "$HOME/.bin"
-  # shellcheck disable=SC2016
-  append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
-fi
-
-echo "change shell to zsh ..."
-##############################
+echo "### change shell to zsh ..."
+#################################
 if [ ! -f "$HOME/.zshrc" ]; then
   touch "$HOME/.zshrc"
 fi
 
 chsh -s "$(which zsh)"
 
-echo "install linux packages ..."
-#################################
+echo "### create lolca bin directory ..."
+########################################
+if [ ! -d "$HOME/.bin/" ]; then
+  mkdir "$HOME/.bin"
+
+  # shellcheck disable=SC2016
+  append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
+fi
+
+echo "### install linux packages ..."
+####################################
+sudo apt update && sudo apt upgrade
 sudo apt install --assume-yes \
   exuberant-ctags \
   git \
@@ -87,103 +86,89 @@ sudo apt install --assume-yes \
   vim \
   zsh
 
-echo "install asdf version manager ..."
-#######################################
+echo "### install asdf version manager ..."
+##########################################
 sudo apt install --assume-yes \
   automake autoconf libreadline-dev libncurses-dev libssl-dev \
   libyaml-dev libxslt-dev libffi-dev libtool make unixodbc-dev
 
 if [ ! -d "$HOME/.asdf" ]; then
   git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.0
+
+  # shellcheck disable=SC2016
+  append_to_zshrc '# Add asdf version manager'
   append_to_zshrc "source $HOME/.asdf/asdf.sh" 1
   append_to_zshrc "source $HOME/.asdf/completions/asdf.bash" 1
 fi
 
-echo "install latest Ruby ..."
-##############################
+# shellcheck disable=SC1090
+source ~/.asdf/asdf.sh
+
+echo "### install latest Ruby ..."
+#################################
 install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 install_asdf_language "ruby"
 
 gem update --system
 gem_install_or_update "bundler"
-number_of_cores=$(sysctl -n hw.ncpu)
+number_of_cores="$(cat /proc/cpuinfo | grep processor | wc -l)"
 bundle config --global jobs $((number_of_cores - 1))
 
-echo "install latest Node ..."
-################################
+echo "### install latest Node ..."
+#################################
 install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 bash "$HOME/.asdf/plugins/nodejs/bin/import-release-team-keyring"
 install_asdf_language "nodejs"
 
-echo "install Linuxbrew ..."
-############################
-# see http://linuxbrew.sh/
-# HOMEBREW_PREFIX="/usr/local"
-#
-# if [ -d "$HOMEBREW_PREFIX" ]; then
-#   if ! [ -r "$HOMEBREW_PREFIX" ]; then
-#     sudo chown -R "$LOGNAME:admin" /usr/local
-#   fi
-# else
-#   sudo mkdir "$HOMEBREW_PREFIX"
-#   sudo chflags norestricted "$HOMEBREW_PREFIX"
-#   sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
-# fi
-#
-# if ! command -v brew >/dev/null; then
-#   fancy_echo "Installing Homebrew ..."
-#     curl -fsS \
-#       'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
-#
-#     append_to_zshrc '# recommended by brew doctor'
-#
-#     # shellcheck disable=SC2016
-#     append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
-#
-#     export PATH="/usr/local/bin:$PATH"
-# fi
-#
-# if brew list | grep -Fq brew-cask; then
-#   fancy_echo "Uninstalling old Homebrew-Cask ..."
-#   brew uninstall --force brew-cask
-# fi
-#
-# fancy_echo "Updating Homebrew formulae ..."
-# brew update --force # https://github.com/Homebrew/brew/issues/1151
+echo "### install Linuxbrew ..."
+###############################
+if ! command -v brew >/dev/null; then
+  # see http://linuxbrew.sh/
+  sudo apt install --assume-yes build-essential
+  sudo curl -fsSL 'https://raw.githubusercontent.com/Linuxbrew/install/master/install' | ruby
+  export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
 
-echo "brew some packages"
-#########################
-# brew bundle --file=- <<EOF
-# tap "thoughtbot/formulae"
-# tap "homebrew/services"
-# tap "caskroom/cask"
-#
-# # Unix
-# brew "rcm"
-# brew "reattach-to-user-namespace"
-# brew "watchman"
-#
-# # GitHub
-# brew "hub"
-#
+  # shellcheck disable=SC2016
+  append_to_zshrc '# Add linuxbrew to PATHs'
+  append_to_zshrc 'export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"' 1
+  append_to_zshrc 'export MANPATH="/home/linuxbrew/.linuxbrew/share/man:$MANPATH"' 1
+  append_to_zshrc 'export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:$INFOPATH"' 1
+fi
+
+echo "### brew some packages"
+############################
+brew update --force # https://github.com/Homebrew/brew/issues/1151
+brew bundle --file=- <<EOF
+tap "thoughtbot/formulae"
+tap "homebrew/services"
+tap "caskroom/cask"
+
+# Unix
+#brew "rcm" via apt!
+#brew "reattach-to-user-namespace"
+brew "watchman"
+
+# GitHub
+brew "hub"
+
 # # Heroku
-# brew "heroku"
-# brew "parity"
-#
+#brew "heroku"
+#brew "parity"
+
 # # Testing
 # brew "qt@5.5" if MacOS::Xcode.installed?
-#
+
 # # Programming language prerequisites and package managers
 # brew "libyaml" # should come after openssl
 # brew "coreutils"
 # brew "yarn"
 # cask "gpg-suite"
-#
+
 # # Databases
 # brew "postgres", restart_service: :changed
 # brew "redis", restart_service: :changed
-# EOF
-#
+EOF
+
 # if brew list | grep --silent "qt@5.5"; then
 #   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
 #   brew unlink qt@5.5
@@ -194,8 +179,8 @@ echo "brew some packages"
 # brew unlink heroku
 # brew link --force heroku
 
-echo "run customizations from ~/.laptop.local ..."
-##################################################
+echo "### run customizations from ~/.laptop.local ..."
+#####################################################
 if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1090
   source "$HOME/.laptop.local"

--- a/linux
+++ b/linux
@@ -101,6 +101,8 @@ sudo apt update && sudo apt install --assume-yes \
   heroku \
   imagemagick \
   openssl \
+  postgresql \
+  redis-server \
   rcm \
   silversearcher-ag \
   tmux \
@@ -132,7 +134,7 @@ install_asdf_language "ruby"
 
 gem update --system
 gem_install_or_update "bundler"
-number_of_cores="$(cat /proc/cpuinfo | grep processor | wc -l)"
+number_of_cores="$(cat < /proc/cpuinfo | grep -c processor)"
 bundle config --global jobs $((number_of_cores - 1))
 
 echo "### install latest Node ..."
@@ -151,8 +153,11 @@ if ! command -v brew >/dev/null; then
 
   # shellcheck disable=SC2016
   append_to_zshrc '# Add linuxbrew to PATHs'
+  # shellcheck disable=SC2016
   append_to_zshrc 'export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"' 1
+  # shellcheck disable=SC2016
   append_to_zshrc 'export MANPATH="/home/linuxbrew/.linuxbrew/share/man:$MANPATH"' 1
+  # shellcheck disable=SC2016
   append_to_zshrc 'export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:$INFOPATH"' 1
 fi
 
@@ -178,7 +183,8 @@ brew "hub"
 #brew "redis", restart_service: :changed
 EOF
 
-# fancy_echo "Update heroku binary..."
+#echo "### update heroku binary..."
+#echo "###########################"
 #brew unlink heroku
 #brew link --force heroku
 

--- a/linux
+++ b/linux
@@ -1,0 +1,203 @@
+#!/bin/sh
+
+# Turn your laptop into an awesome development machine, to get logs do
+# sh linux 2>&1 | tee ~/setup.log
+
+set -o xtrace  # aka 'set -x' to trace what gets executed
+set -o errexit # aka 'set -e' to exit when command fails
+# shellcheck disable=SC2154
+#trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+
+echo "create some helper functions ..."
+#######################################
+append_to_zshrc() {
+  local text="$1" zshrc
+  local skip_new_line="${2:-0}"
+
+  if [ -w "$HOME/.zshrc.local" ]; then
+    zshrc="$HOME/.zshrc.local"
+  else
+    zshrc="$HOME/.zshrc"
+  fi
+
+  if ! grep -Fqs "$text" "$zshrc"; then
+    if [ "$skip_new_line" -eq 1 ]; then
+      printf "%s\n" "$text" >> "$zshrc"
+    else
+      printf "\n%s\n" "$text" >> "$zshrc"
+    fi
+  fi
+
+  source "$zshrc"
+}
+
+install_asdf_plugin() {
+  local name="$1"
+  local url="$2"
+
+  if ! asdf plugin-list | grep -Fq "$name"; then
+    asdf plugin-add "$name" "$url"
+  fi
+}
+
+install_asdf_language() {
+  local language="$1"
+  local version
+  version="$(asdf list-all "$language" | tail -1)"
+
+  if ! asdf list "$language" | grep -Fq "$version"; then
+    asdf install "$language" "$version"
+    asdf global "$language" "$version"
+  fi
+}
+
+gem_install_or_update() {
+  if gem list "$1" --installed > /dev/null; then
+    gem update "$@"
+  else
+    gem install "$@"
+  fi
+}
+
+echo "create lolca bin directory ..."
+#####################################
+if [ ! -d "$HOME/.bin/" ]; then
+  mkdir "$HOME/.bin"
+  # shellcheck disable=SC2016
+  append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
+fi
+
+echo "change shell to zsh ..."
+##############################
+if [ ! -f "$HOME/.zshrc" ]; then
+  touch "$HOME/.zshrc"
+fi
+
+chsh -s "$(which zsh)"
+
+echo "install linux packages ..."
+#################################
+sudo apt install --assume-yes \
+  exuberant-ctags \
+  git \
+  imagemagick \
+  openssl \
+  silversearcher-ag \
+  tmux \
+  vim \
+  zsh
+
+echo "install asdf version manager ..."
+#######################################
+sudo apt install --assume-yes \
+  automake autoconf libreadline-dev libncurses-dev libssl-dev \
+  libyaml-dev libxslt-dev libffi-dev libtool make unixodbc-dev
+
+if [ ! -d "$HOME/.asdf" ]; then
+  git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.0
+  append_to_zshrc "source $HOME/.asdf/asdf.sh" 1
+  append_to_zshrc "source $HOME/.asdf/completions/asdf.bash" 1
+fi
+
+echo "install latest Ruby ..."
+##############################
+install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
+install_asdf_language "ruby"
+
+gem update --system
+gem_install_or_update "bundler"
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
+
+echo "install latest Node ..."
+################################
+install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
+bash "$HOME/.asdf/plugins/nodejs/bin/import-release-team-keyring"
+install_asdf_language "nodejs"
+
+echo "install Linuxbrew ..."
+############################
+# see http://linuxbrew.sh/
+# HOMEBREW_PREFIX="/usr/local"
+#
+# if [ -d "$HOMEBREW_PREFIX" ]; then
+#   if ! [ -r "$HOMEBREW_PREFIX" ]; then
+#     sudo chown -R "$LOGNAME:admin" /usr/local
+#   fi
+# else
+#   sudo mkdir "$HOMEBREW_PREFIX"
+#   sudo chflags norestricted "$HOMEBREW_PREFIX"
+#   sudo chown -R "$LOGNAME:admin" "$HOMEBREW_PREFIX"
+# fi
+#
+# if ! command -v brew >/dev/null; then
+#   fancy_echo "Installing Homebrew ..."
+#     curl -fsS \
+#       'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+#
+#     append_to_zshrc '# recommended by brew doctor'
+#
+#     # shellcheck disable=SC2016
+#     append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
+#
+#     export PATH="/usr/local/bin:$PATH"
+# fi
+#
+# if brew list | grep -Fq brew-cask; then
+#   fancy_echo "Uninstalling old Homebrew-Cask ..."
+#   brew uninstall --force brew-cask
+# fi
+#
+# fancy_echo "Updating Homebrew formulae ..."
+# brew update --force # https://github.com/Homebrew/brew/issues/1151
+
+echo "brew some packages"
+#########################
+# brew bundle --file=- <<EOF
+# tap "thoughtbot/formulae"
+# tap "homebrew/services"
+# tap "caskroom/cask"
+#
+# # Unix
+# brew "rcm"
+# brew "reattach-to-user-namespace"
+# brew "watchman"
+#
+# # GitHub
+# brew "hub"
+#
+# # Heroku
+# brew "heroku"
+# brew "parity"
+#
+# # Testing
+# brew "qt@5.5" if MacOS::Xcode.installed?
+#
+# # Programming language prerequisites and package managers
+# brew "libyaml" # should come after openssl
+# brew "coreutils"
+# brew "yarn"
+# cask "gpg-suite"
+#
+# # Databases
+# brew "postgres", restart_service: :changed
+# brew "redis", restart_service: :changed
+# EOF
+#
+# if brew list | grep --silent "qt@5.5"; then
+#   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
+#   brew unlink qt@5.5
+#   brew link --force qt@5.5
+# fi
+#
+# fancy_echo "Update heroku binary..."
+# brew unlink heroku
+# brew link --force heroku
+
+echo "run customizations from ~/.laptop.local ..."
+##################################################
+if [ -f "$HOME/.laptop.local" ]; then
+  # shellcheck disable=SC1090
+  source "$HOME/.laptop.local"
+  # include aptitude mc shellcheck
+fi

--- a/linux
+++ b/linux
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Turn your laptop into an awesome development machine.
 # Usage: $ bash linux 2>&1 | tee ~/setup.log
 
@@ -7,8 +8,8 @@ set -o errexit # aka 'set -e' to exit when command fails
 # shellcheck disable=SC2154
 trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
 
-echo "### create some helper functions ..."
-##########################################
+### create some helper functions ...
+####################################
 append_to_zshrc() {
   local text="$1" zshrc
   local skip_new_line="${2:-0}"
@@ -57,15 +58,15 @@ gem_install_or_update() {
 }
 
 echo "### change shell to zsh ..."
-#################################
+echo "###########################"
 if [ ! -f "$HOME/.zshrc" ]; then
   touch "$HOME/.zshrc"
 fi
 
 chsh -s "$(which zsh)"
 
-echo "### create lolca bin directory ..."
-########################################
+echo "### create local bin directory ..."
+echo "##################################"
 if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
 
@@ -73,21 +74,41 @@ if [ ! -d "$HOME/.bin/" ]; then
   append_to_zshrc 'export PATH="$HOME/.bin:$PATH"'
 fi
 
-echo "### install linux packages ..."
-####################################
-sudo apt update && sudo apt upgrade
-sudo apt install --assume-yes \
+echo "### add other source repositories ..."
+echo "#####################################"
+wget -qO- https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable edge" | sudo tee /etc/apt/sources.list.d/docker.list
+
+# TODO consider standalone installation for auto updating feature
+wget -qO- https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+echo "deb https://cli-assets.heroku.com/branches/stable/apt ./" | sudo tee /etc/apt/sources.list.d/heroku.list
+
+# TODO consider pull-request to use 'brew install rcm' instead
+wget -qO- https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
+echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
+
+wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+echo "### install base linux packages ..."
+echo "###################################"
+sudo apt update && sudo apt install --assume-yes \
+  docker-ce \
   exuberant-ctags \
   git \
+  heroku \
   imagemagick \
   openssl \
+  rcm \
   silversearcher-ag \
   tmux \
   vim \
   zsh
 
 echo "### install asdf version manager ..."
-##########################################
+echo "####################################"
 sudo apt install --assume-yes \
   automake autoconf libreadline-dev libncurses-dev libssl-dev \
   libyaml-dev libxslt-dev libffi-dev libtool make unixodbc-dev
@@ -105,7 +126,7 @@ fi
 source ~/.asdf/asdf.sh
 
 echo "### install latest Ruby ..."
-#################################
+echo "###########################"
 install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 install_asdf_language "ruby"
 
@@ -115,13 +136,13 @@ number_of_cores="$(cat /proc/cpuinfo | grep processor | wc -l)"
 bundle config --global jobs $((number_of_cores - 1))
 
 echo "### install latest Node ..."
-#################################
+echo "###########################"
 install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 bash "$HOME/.asdf/plugins/nodejs/bin/import-release-team-keyring"
 install_asdf_language "nodejs"
 
 echo "### install Linuxbrew ..."
-###############################
+echo "#########################"
 if ! command -v brew >/dev/null; then
   # see http://linuxbrew.sh/
   sudo apt install --assume-yes build-essential
@@ -135,54 +156,35 @@ if ! command -v brew >/dev/null; then
   append_to_zshrc 'export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:$INFOPATH"' 1
 fi
 
-echo "### brew some packages"
-############################
+echo "### brew some packages ..."
+echo "##########################"
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "thoughtbot/formulae"
-tap "homebrew/services"
-tap "caskroom/cask"
+#tap "thoughtbot/formulae"
 
 # Unix
-#brew "rcm" via apt!
-#brew "reattach-to-user-namespace"
+#brew "rcm"
 brew "watchman"
 
 # GitHub
 brew "hub"
 
-# # Heroku
+# Heroku
 #brew "heroku"
 #brew "parity"
 
-# # Testing
-# brew "qt@5.5" if MacOS::Xcode.installed?
-
-# # Programming language prerequisites and package managers
-# brew "libyaml" # should come after openssl
-# brew "coreutils"
-# brew "yarn"
-# cask "gpg-suite"
-
-# # Databases
-# brew "postgres", restart_service: :changed
-# brew "redis", restart_service: :changed
+# Databases
+#brew "postgres", restart_service: :changed
+#brew "redis", restart_service: :changed
 EOF
 
-# if brew list | grep --silent "qt@5.5"; then
-#   fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit..."
-#   brew unlink qt@5.5
-#   brew link --force qt@5.5
-# fi
-#
 # fancy_echo "Update heroku binary..."
-# brew unlink heroku
-# brew link --force heroku
+#brew unlink heroku
+#brew link --force heroku
 
 echo "### run customizations from ~/.laptop.local ..."
-#####################################################
+echo "###############################################"
 if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1090
   source "$HOME/.laptop.local"
-  # include aptitude mc shellcheck
 fi

--- a/linux
+++ b/linux
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Turn your laptop into an awesome development machine.
-# Usage: $ bash linux 2>&1 | tee ~/setup.log
+# Usage: $ bash linux 2>&1 | tee ~/laptop.log
 
 #set -o xtrace  # aka 'set -x' to trace what gets executed ... for debugging
 set -o errexit # aka 'set -e' to exit when command fails
@@ -76,8 +76,8 @@ fi
 
 echo "### add other source repositories ..."
 echo "#####################################"
-wget -qO- https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+wget -qO- https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add -
+echo "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
   $(lsb_release -cs) \
   stable edge" | sudo tee /etc/apt/sources.list.d/docker.list
 
@@ -89,6 +89,7 @@ echo "deb https://cli-assets.heroku.com/branches/stable/apt ./" | sudo tee /etc/
 wget -qO- https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add -
 echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list
 
+# TODO test 'brew install yarn' on linux compatibilty
 wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
@@ -164,6 +165,8 @@ fi
 echo "### brew some packages ..."
 echo "##########################"
 brew update --force # https://github.com/Homebrew/brew/issues/1151
+# TODO consider pull-request for linux compatibilty of thoughtbot/formulae
+# to install heroku, parity, rcm via brew
 brew bundle --file=- <<EOF
 #tap "thoughtbot/formulae"
 


### PR DESCRIPTION
Hi,
I know you dropped Linux support a long time ago (https://github.com/thoughtbot/laptop/blob/3897ad81ee241cbff4501e779c8cde50de79e142/linux).

Nevertheless every other year I come back to orientate myself at the Mac-script about new/changed tooling and/or approaches in the Ruby world, and than applying it manually on my Linux box.

This time I took the extra mile to put it in a Linux-script and would be happy, if you accept the Pull-request.

Please be aware of following Mac- vs. Linux-script differences, which might not be obvious from first look into README ... The Linux-script

* aims just on Debian/ Ubuntu based distros
* uses 'bash' instead of 'sh', cause on Linux machines
  * you face "/bin/sh -> dash", so `source` of scripts does not work and
  * `$HOME/.asdf/completions/asdf.bash` would not work either
* has helper functions condensed at the top and slightly adjusted
* makes mainly use of official Linux repositories, but also
  * adds some other repositories for docker, heroku, rcm and yarn packages
  * gives additional flexibility with Linuxbrew
* installs `docker-ce` natively
* has some TODO marks for possible improvements

I am open for suggestions to adjust.

Happy week,
best harm/