### PR TITLE
Updates version of `asdf` that is installed.

### DIFF
--- a/mac
+++ b/mac
@@ -163,7 +163,7 @@ brew link --force heroku
 
 fancy_echo "Configuring asdf version manager..."
 if [ ! -d "$HOME/.asdf" ]; then
-  git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.3.0
+  git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.2
   append_to_zshrc "source $HOME/.asdf/asdf.sh" 1
 fi
 


### PR DESCRIPTION
Updates the`asdf` install section to pull in the most up-to-date version of `asdf`
at the time of this commit.

I was also considering adding an additional call to `append_to_zshrc` to source `$HOME/.asdf/completions/asdf.bash` like what is mentioned in the [setup](https://github.com/asdf-vm/asdf#setup) portion of the README, but wasn't sure if it was intentionally ignored. 