### PR TITLE
Only install released MRI versions of Ruby

### DIFF
--- a/mac
+++ b/mac
@@ -184,7 +184,7 @@ install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list-all "$language" | tail -1)"
+  version="$(asdf list-all "$language" | grep -v "[a-z]" | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"


### PR DESCRIPTION
Fixes #533 and may make #515 unnecessary.

When installing Ruby and Node, we use `asdf list-all` to find the
latest version. For Ruby, the list includes previews and release
candidates as well as non-MRI versions. The script failed for me because
it tried to install version `ree-1.8.7-2012.02`. Filtering out
versions with letters should ensure we only install fully released MRI
versions.