### PR TITLE
Fix asdf ruby installation

### DIFF
--- a/mac
+++ b/mac
@@ -176,6 +176,7 @@ install_asdf_plugin() {
   fi
 }
 
+# shellcheck disable=SC2039
 # shellcheck disable=SC1090
 source "$HOME/.asdf/asdf.sh"
 install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
@@ -184,7 +185,7 @@ install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list-all "$language" | tail -1)"
+  version="$(asdf list-all "$language" | grep -E '^\d+(\.\d+)+$' | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"

--- a/mac
+++ b/mac
@@ -176,7 +176,6 @@ install_asdf_plugin() {
   fi
 }
 
-# shellcheck disable=SC2039
 # shellcheck disable=SC1090
 source "$HOME/.asdf/asdf.sh"
 install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"


### PR DESCRIPTION
This script breaks for me on a fresh install because it tries to install ruby ree-1.8.7 which requires apple-gcc42. I'm assuming this script intended to install the highest normal ruby release.