### PR TITLE
Add support for MacOS High Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ We support:
 * macOS Yosemite (10.10)
 * macOS El Capitan (10.11)
 * macOS Sierra (10.12)
+* macOS High Sierra (10.13)
 
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.


### PR DESCRIPTION
I ran the script on MacOS 10.13.5 and did not see any unexplained failures.

I don't care about asdf so I did not run commands that require asdf. Everything else checked out well.