### PR TITLE
Heroku formula was removed from homebrew core

### DIFF
--- a/mac
+++ b/mac
@@ -114,6 +114,7 @@ tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
 tap "caskroom/cask"
+tap "heroku/brew"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]


### PR DESCRIPTION
- Add brew tap for official formula

https://github.com/Homebrew/homebrew-core/pull/33233