### PR TITLE
Add a tap for heroku

### DIFF
--- a/mac
+++ b/mac
@@ -129,7 +129,7 @@ brew "watchman"
 brew "zsh"
 
 # Heroku
-brew "heroku"
+brew "heroku/brew/heroku"
 brew "parity"
 
 # GitHub

--- a/mac
+++ b/mac
@@ -114,6 +114,7 @@ tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
 tap "caskroom/cask"
+tap "heroku/brew"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]


### PR DESCRIPTION
The Heroku install was not working for me until I made this change. 
Fresh install on OS X High Sierra.