### PR TITLE
Remove Qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,6 @@ Image tools:
 
 * [ImageMagick] for cropping and resizing images
 
-Testing tools:
-
-* [Qt 5] for headless JavaScript testing via [Capybara Webkit]
-
-[Qt 5]: http://qt-project.org/
-[Capybara Webkit]: https://github.com/thoughtbot/capybara-webkit
-
 Programming languages, package managers, and configuration:
 
 * [ASDF] for managing programming language versions

--- a/mac
+++ b/mac
@@ -138,9 +138,6 @@ brew "hub"
 # Image manipulation
 brew "imagemagick"
 
-# Testing
-brew "qt@5.5" if MacOS::Xcode.installed?
-
 # Programming language prerequisites and package managers
 brew "libyaml" # should come after openssl
 brew "coreutils"
@@ -151,12 +148,6 @@ cask "gpg-suite"
 brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
-
-if brew list | grep --silent "qt@5.5"; then
-  fancy_echo "Symlink qmake binary to /usr/local/bin for Capybara Webkit ..."
-  brew unlink qt@5.5
-  brew link --force qt@5.5
-fi
 
 fancy_echo "Update heroku binary ..."
 brew unlink heroku


### PR DESCRIPTION
Qt, a dependency on capybara-webkit, causes a lot of install problems
and most recently more so. We're not using capybara-webkit so much now,
so we don't absolutely need Qt.

Fixes #499.