### PR TITLE
Update asdf plugins already installed

### DIFF
--- a/mac
+++ b/mac
@@ -159,19 +159,21 @@ if [ ! -d "$HOME/.asdf" ]; then
   append_to_zshrc "source $HOME/.asdf/asdf.sh" 1
 fi
 
-install_asdf_plugin() {
+add_or_update_asdf_plugin() {
   local name="$1"
   local url="$2"
 
   if ! asdf plugin-list | grep -Fq "$name"; then
     asdf plugin-add "$name" "$url"
+  else
+    asdf plugin-update "$name"
   fi
 }
 
 # shellcheck disable=SC1090
 source "$HOME/.asdf/asdf.sh"
-install_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
-install_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
+add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
+add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 
 install_asdf_language() {
   local language="$1"

--- a/mac
+++ b/mac
@@ -159,6 +159,7 @@ if [ ! -d "$HOME/.asdf" ]; then
   append_to_zshrc "source $HOME/.asdf/asdf.sh" 1
 fi
 
+alias install_asdf_plugin=add_or_update_asdf_plugin
 add_or_update_asdf_plugin() {
   local name="$1"
   local url="$2"


### PR DESCRIPTION
Keep any asdf plugins installed by this script up-to-date.

This may resolve some issues when updating languages, especially nodejs where the asdf plugin maintains the signing keys required to verify the package.

I chose `add_or_update_asdf_plugin` rather than `install_or_update_asdf_plugin` to keep the line lengths shorter when being called - it also matches the asdf api.

We maintain an alias for `install_asdf_plugin` incase anyone's `laptop.local` uses it.