### PR TITLE
fix(laptop): remove redundant gem

### DIFF
--- a/mac
+++ b/mac
@@ -190,7 +190,6 @@ install_asdf_language() {
 fancy_echo "Installing latest Ruby ..."
 install_asdf_language "ruby"
 gem update --system
-gem_install_or_update "bundler"
 number_of_cores=$(sysctl -n hw.ncpu)
 bundle config --global jobs $((number_of_cores - 1))
 


### PR DESCRIPTION
The bundler gem is included as of ruby 2.6.0. Manually adding it is generating an error. This will get rid of the error.

Discussed [here](https://github.com/thoughtbot/laptop/issues/543)