### PR TITLE
Drop tapping of Homebrew cask

### DIFF
--- a/mac
+++ b/mac
@@ -113,7 +113,6 @@ brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
-tap "homebrew/cask-cask"
 tap "heroku/brew"
 
 # Unix


### PR DESCRIPTION
People used to have to tap Homebrew cask to use the `cask` command. Homebrew have now integrated `cask` into the primary package manager. `mac` was raising an error because the tap repository no longer exists. We have dropped the tapping of `"homebrew/cask-cask"` from `mac`.