### PR TITLE
Replace hub with GitHub CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Heroku tools:
 
 GitHub tools:
 
-* [Hub] for interacting with the GitHub API
+* [GitHub CLI] for interacting with the GitHub API
 
-[Hub]: http://hub.github.com/
+[GitHub CLI]: https://cli.github.com/
 
 Image tools:
 

--- a/mac
+++ b/mac
@@ -132,7 +132,7 @@ brew "heroku/brew/heroku"
 brew "parity"
 
 # GitHub
-brew "github/gh/gh"
+brew "gh"
 
 # Image manipulation
 brew "imagemagick"

--- a/mac
+++ b/mac
@@ -132,7 +132,7 @@ brew "heroku/brew/heroku"
 brew "parity"
 
 # GitHub
-brew "hub"
+brew "github/gh/gh"
 
 # Image manipulation
 brew "imagemagick"


### PR DESCRIPTION
GitHub has [announced GitHub CLI][announcement]. While hub was
semi-official, GitHub CLI is said to be GitHub’s new official CLI.

The backstory on hub and how GitHub CLI came to be can be read in the
post [‘The past and the future of hub’][hub-post] by Mislav Marohnić,
hub’s core maintainer.

[announcement]: https://github.blog/2020-02-12-supercharge-your-command-line-experience-github-cli-is-now-in-beta/
[hub-post]: https://mislav.net/2020/01/github-cli/