### PR TITLE
Update ctags installation command

### DIFF
--- a/mac
+++ b/mac
@@ -112,11 +112,10 @@ brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
-tap "universal-ctags/universal-ctags"
 tap "heroku/brew"
 
 # Unix
-brew "universal-ctags", args: ["HEAD"]
+brew "universal-ctags/universal-ctags/universal-ctags", args: ["HEAD"]
 brew "git"
 brew "openssl"
 brew "rcm"


### PR DESCRIPTION
closes https://github.com/thoughtbot/laptop/issues/584

The tap universal-ctags is not available anymore and these are the official instructions to install ctags.

Refer: https://github.com/universal-ctags/homebrew-universal-ctags