### PR TITLE
Replace deprecated homebrew install command

### DIFF
--- a/mac
+++ b/mac
@@ -91,8 +91,8 @@ gem_install_or_update() {
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+    /bin/bash -c \
+      "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
     append_to_zshrc '# recommended by brew doctor'
 


### PR DESCRIPTION
The script we are currently using outputs a deprecation warning telling us to use this new bash script. See https://raw.githubusercontent.com/Homebrew/install/master/install

```
#!/usr/bin/ruby

STDERR.print <<EOS
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

EOS

Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"'
```