### PR TITLE
Ignore shellcheck warning SC3043 globally in script

### DIFF
--- a/mac
+++ b/mac
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC3043
 
 # Welcome to the thoughtbot laptop script!
 # Be prepared to turn your laptop (or desktop, no haters here)


### PR DESCRIPTION
This warning states that "In POSIX sh, 'local' is undefined".

`local` is used extensively in the mac script, but it should be
understood by most OSes based on the information in:
https://stackoverflow.com/questions/18597697/posix-compliant-way-to-scope-variables-to-a-function-in-a-shell-script#answer-18600920

Add a line at the beginning of the script to ignore this warning
in the entire file to avoid false positives when linting locally.
