### PR TITLE
Officially only list support for Monterey

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ Requirements
 
 We support:
 
-* macOS Mavericks (10.9)
-* macOS Yosemite (10.10)
-* macOS El Capitan (10.11)
-* macOS Sierra (10.12)
-* macOS High Sierra (10.13)
-* macOS Mojave (10.14)
-* macOS Catalina (10.15)
+* macOS Monterey (12.3) on Apple Silicon and Intel
 
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.
@@ -214,7 +208,7 @@ you agree to abide by the thoughtbot [code of conduct].
 License
 -------
 
-Laptop is © 2011-2020 thoughtbot, inc.
+Laptop is © 2011-2022 thoughtbot, inc.
 It is free software,
 and may be redistributed under the terms specified in the [LICENSE] file.
 


### PR DESCRIPTION
While older versions may work, it is unrealistic for us to claim
official support for such old versions.

Also updates the copyright date.

This change is dependent on
https://github.com/thoughtbot/laptop/pull/602
