### PR TITLE
Add testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ brew install shellcheck
 [ShellCheck]: http://www.shellcheck.net/about.html
 [Syntastic]: https://github.com/scrooloose/syntastic
 
+### Testing your changes
+
+Test your changes by running the script on a fresh install of macOS.
+You can use the free and open source emulator [UTM].
+
+Tip: Make a fresh virtual machine with the installation of macOS completed and
+your user created and first launch complete. Then duplicate that machine to test
+the script each time on a fresh install thats ready to go.
+
+[UTM]: https://mac.getutm.app
+
 Thank you, [contributors]!
 
 [contributors]: https://github.com/thoughtbot/laptop/graphs/contributors


### PR DESCRIPTION
We can recommend a free and open source emulator and provide tips to it in the README to make it easier to make sure we're not introducing breaking changes when we contribute.

In the future I also want to see if we could add CI to this project now that macOS CI setup is more widely available than it has been in the past.