### PR TITLE
Ignore shellcheck warning SC3043 globally

### DIFF
--- a/mac
+++ b/mac
@@ -4,6 +4,8 @@
 # Be prepared to turn your laptop (or desktop, no haters here)
 # into an awesome development machine.
 
+# shellcheck disable=SC3043
+
 fancy_echo() {
   local fmt="$1"; shift
 


### PR DESCRIPTION
This warning states that "In POSIX sh, 'local' is undefined".

`local` is used extensively in the mac script, but it should be
understood by most OSes based on the information in:
https://stackoverflow.com/questions/18597697/posix-compliant-way-to-scope-variables-to-a-function-in-a-shell-script#answer-18600920

Add a line at the beginning of the script to ignore this warning
in the entire file to avoid false positives when linting locally.

Co-authored-by: rreinhardt9
