### PR TITLE
Use gpg-suite-no-mail

### DIFF
--- a/mac
+++ b/mac
@@ -134,6 +134,7 @@ brew "imagemagick"
 brew "libyaml" # should come after openssl
 brew "coreutils"
 brew "yarn"
+cask "gpg-suite"
 
 # Databases
 brew "postgres", restart_service: :changed

--- a/mac
+++ b/mac
@@ -134,12 +134,13 @@ brew "imagemagick"
 brew "libyaml" # should come after openssl
 brew "coreutils"
 brew "yarn"
-cask "gpg-suite"
 
 # Databases
 brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
+
+rm /Library/Mail/Bundles/GPGMail.mailbundle
 
 fancy_echo "Update heroku binary ..."
 brew unlink heroku

--- a/mac
+++ b/mac
@@ -134,14 +134,12 @@ brew "imagemagick"
 brew "libyaml" # should come after openssl
 brew "coreutils"
 brew "yarn"
-cask "gpg-suite"
+cask "gpg-suite-no-mail"
 
 # Databases
 brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
-
-rm /Library/Mail/Bundles/GPGMail.mailbundle
 
 fancy_echo "Update heroku binary ..."
 brew unlink heroku


### PR DESCRIPTION
Closes #575
Closes #531

This is an alternate PR to #532.

I discovered that there is an alternative to the gpg-suite which passes flags to the installer to not install the optional Mail.app extension.