### PR TITLE
🐛 Fix the PostgreSQL Homebrew definition

### DIFF
--- a/mac
+++ b/mac
@@ -138,7 +138,7 @@ brew "yarn"
 cask "gpg-suite-no-mail"
 
 # Databases
-brew "postgres", restart_service: :changed
+brew "postgresql@14", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
 


### PR DESCRIPTION
Before, we used the simple `postgres` alias to install PostgreSQL with Homebrew. Homebrew has removed this alias and needs us to define the required version. We fixed the definition to use the full formula name and define a version.
