### PR TITLE
Install poppler via homebrew on mac

### DIFF
--- a/mac
+++ b/mac
@@ -131,6 +131,9 @@ brew "gh"
 # Image manipulation
 brew "imagemagick"
 
+# PDF Rendering
+brew "poppler"
+
 # Programming language prerequisites and package managers
 brew "libyaml" # should come after openssl
 brew "coreutils"


### PR DESCRIPTION
* I setup my new macbook recently using laptop. One of the projects I
  have been working on had a failing spec related to pdf previews with
  ActiveStorage preview. The spec worked fine on CI but Ubuntu has
  poppler-utils installed by default.
* Add line to mac script to install poppler via homebrew
