### PR TITLE
Introduce a changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
 A description of your change.
 
-- [ ] [Changes tested on a Fresh install of macOS](https://github.com/thoughtbot/laptop#testing-your-changes) (Not _required_ by you, but good to know whether it has been done so that the maintainers can do it if you did not)
 - [ ] Updated CHANGELOG
 - [ ] Updated README.md (if necessary)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+A description of your change.
+
+- [ ] [Changes tested on a Fresh install of macOS](https://github.com/thoughtbot/laptop#testing-your-changes) (Not _required_ by you, but good to know whether it has been done so that the maintainers can do it if you did not)
+- [ ] Updated CHANGELOG
+- [ ] Updated README.md (if necessary)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixes 
+
+* [The PostgreSQL Homebrew definition has been fixed](https://github.com/thoughtbot/laptop/pull/612)
+
+## 2022-03-30
+
+### Changed
+
+* Official support for macOS Monterey on Apple Silicon and Intel and removes official support for prior versions of macOS.
+* [Use brew asdk, changes for latest node](https://github.com/thoughtbot/laptop/pull/608)
+* [Ignore shellcheck warning SC3043 globally](https://github.com/thoughtbot/laptop/pull/606)
+* [Use gpg-suite-no-mail](https://github.com/thoughtbot/laptop/pull/607)
+* [Update ctags installation command](https://github.com/thoughtbot/laptop/pull/586)
+


### PR DESCRIPTION
Closes #522

This introduces a changelog to accompany the tagging of releases. Along with the changelog, as suggested in #522, it also introduced a PR template that has a checklist item for updatign the changelog, as well as the readme, if necessary.