### PR TITLE
Return error code for failure sourcing asdf.sh

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Fixed 
+### Fixed
 
 * [The PostgreSQL Homebrew definition has been fixed](https://github.com/thoughtbot/laptop/pull/612)
+* [Return error code for failure sourcing asdf.sh](https://github.com/thoughtbot/laptop/pull/620)
 
 ## 2022-03-30
 

--- a/mac
+++ b/mac
@@ -168,7 +168,11 @@ add_or_update_asdf_plugin() {
 }
 
 # shellcheck disable=SC1091
-. "$(brew --prefix asdf)/asdf.sh"
+sh "$(brew --prefix asdf)/asdf.sh"
+asdfShExitCode=$?
+if [ $asdfShExitCode -ne 0 ]; then
+  exit $asdfShExitCode
+fi
 add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 


### PR DESCRIPTION
source (or `.`) is a built in command and as a result it halts script
execution, and the error code from the command is not returned. This
resulted in the exit code of the script in this case being `0` rather
than the error code of the source command, which is 127 (command not
found).
