### PR TITLE
Add support for macOS Ventura

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,0 @@
-macos_instance:
-  image: ghcr.io/cirruslabs/macos-monterey-base:latest
-
-task:
-  script: sh mac

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+* Support for macOS Ventura
+
 ### Fixed
 
 * [The PostgreSQL Homebrew definition has been fixed](https://github.com/thoughtbot/laptop/pull/612)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://api.cirrus-ci.com/github/thoughtbot/laptop.svg)](https://cirrus-ci.com/github/thoughtbot/laptop)
-
 Laptop
 ======
 
@@ -14,7 +12,8 @@ Requirements
 
 We support:
 
-* macOS Monterey (12.3) on Apple Silicon and Intel
+* macOS Ventura (13.x) on Apple Silicon and Intel
+* macOS Monterey (12.x) on Apple Silicon and Intel
 
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.


### PR DESCRIPTION
Closes #617

This adds support for macOS Ventura. It also introduces a build matrix
on CI to run the build on moth Monterey and Ventura.
