### PR TITLE
Fix sourcing of asdf.sh

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * [The PostgreSQL Homebrew definition has been fixed](https://github.com/thoughtbot/laptop/pull/612)
 * [Return error code for failure sourcing asdf.sh](https://github.com/thoughtbot/laptop/pull/620)
+* [Fix for location change of asdf.sh](https://github.com/thoughtbot/laptop/pull/623)
 
 ## 2022-03-30
 

--- a/mac
+++ b/mac
@@ -152,7 +152,7 @@ brew link --force heroku
 fancy_echo "Configuring asdf version manager ..."
 if [ ! -d "$HOME/.asdf" ]; then
   brew install asdf
-  append_to_zshrc "source $(brew --prefix asdf)/asdf.sh" 1
+  append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
 fi
 
 alias install_asdf_plugin=add_or_update_asdf_plugin
@@ -168,11 +168,7 @@ add_or_update_asdf_plugin() {
 }
 
 # shellcheck disable=SC1091
-sh "$(brew --prefix asdf)/asdf.sh"
-asdfShExitCode=$?
-if [ $asdfShExitCode -ne 0 ]; then
-  exit $asdfShExitCode
-fi
+. "$(brew --prefix asdf)/libexec/asdf.sh"
 add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 


### PR DESCRIPTION
Installing asdf via Homebrew now says:

```
To use asdf, add the following line to your ~/.zshrc:
  . /opt/homebrew/opt/asdf/libexec/asdf.sh
```

Yes, the laptop script is doing:

`. /opt/homebrew/opt/asdf/asdf.sh`

This used to work, but in no longer does because of the change in
https://github.com/Homebrew/homebrew-core/pull/81664

This corrects the file location being source.

This failure was showing in CI and UTM locally for me.
