### PR TITLE
Fix cleanup cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ fi
 
 fancy_echo "Cleaning up old Homebrew formulae ..."
 brew cleanup
-brew cask cleanup
 
 if [ -r "$HOME/.rcrc" ]; then
   fancy_echo "Updating dotfiles ..."


### PR DESCRIPTION
### A description of your change.

- [ ] Updated CHANGELOG
- [x] Updated README.md (if necessary)

### Why is this PR introduced?
```bash
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
failed
```