### PR TITLE
HOMEBREW_PREFIX in zsh path

### DIFF
--- a/mac
+++ b/mac
@@ -70,7 +70,7 @@ update_shell() {
 
 case "$SHELL" in
   */zsh)
-    if [ "$(command -v zsh)" != '/usr/local/bin/zsh' ] ; then
+    if [ "$(command -v zsh)" != "$HOMEBREW_PREFIX/bin/zsh" ] ; then
       update_shell
     fi
     ;;


### PR DESCRIPTION
Closes #630

This change will improve support for both Intel and Apple Silicon Macs

- [x] Interpolated `HOMEBREW_PREFIX` in zsh path
