### PR TITLE
Remove @thoughtbot/thoughtbot from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global rule:
-*           @cpytel @thoughtbot/thoughtbot
+*           @cpytel


### PR DESCRIPTION
It seems adding `@thoughtbot/thoughtbot` to CODEOWNERS triggers notifications for everyone in the organization (the whole company).

This change remove this codeowner.
