### PR TITLE
Switch syntastic to ALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ you agree to abide by the thoughtbot [code of conduct].
 Edit the `mac` file.
 Document in the `README.md` file.
 Update the `CHANGELOG`.
-Follow shell style guidelines by using [ShellCheck] and [Syntastic].
+Follow shell style guidelines by using [ShellCheck] and [ALE] or deprecated [Syntastic].
 
 ```sh
 brew install shellcheck
@@ -209,6 +209,8 @@ brew install shellcheck
 
 [ShellCheck]: http://www.shellcheck.net/about.html
 [Syntastic]: https://github.com/scrooloose/syntastic
+[ALE]: https://github.com/dense-analysis/ale
+
 
 ### Testing your changes
 


### PR DESCRIPTION
Notes from Syntastic:


> 1. Deprecation note
>
> This project is no longer maintained. If you need a syntax checking plugin for Vim you might be interested in Syntastic's spiritual succesor, ALE. Although it shares no code with syntastic and it takes a very different approach to design, ALE can be considered a natural evolution of syntastic in terms of goals and functionality. Check it out, you probably won't be disappointed.


- [ ] Updated CHANGELOG
- [x] Updated README.md (if necessary)
