### PR TITLE
Removed homebrew/services

### DIFF
--- a/mac
+++ b/mac
@@ -121,7 +121,6 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
-tap "homebrew/services"
 tap "heroku/brew"
 
 # Unix


### PR DESCRIPTION
Looks like homebrew/services tap has been deprecated and integrated into Homebrew Core.