### PR TITLE
Updates for latest versions of asdf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2025-06-25
 
-* Update asdf commands to work with latest versions
+* asdf is now updated if it is already installed and asdf commands were updated
+  to work with latest versions.
 
 ## 2024-09-24
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## 2025-06-25
+
+* Update asdf commands to work with latest versions
+
 ## 2024-09-24
 
 * Support for macOS Sequoia

--- a/mac
+++ b/mac
@@ -194,7 +194,7 @@ install_asdf_language() {
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"
-    asdf global "$language" "$version"
+    asdf set --home "$language" "$version"
   fi
 }
 

--- a/mac
+++ b/mac
@@ -168,6 +168,8 @@ fancy_echo "Configuring asdf version manager ..."
 if [ ! -d "$HOME/.asdf" ]; then
   brew install asdf
   append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
+else
+  brew upgrade asdf
 fi
 
 alias install_asdf_plugin=add_or_update_asdf_plugin

--- a/mac
+++ b/mac
@@ -190,7 +190,7 @@ add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list all "$language" | grep -v "[a-z]" | tail -1)"
+  version="$(asdf list all "$language" | grep -v "[a-z]" | tr -s '\n' | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"

--- a/mac
+++ b/mac
@@ -175,10 +175,10 @@ add_or_update_asdf_plugin() {
   local name="$1"
   local url="$2"
 
-  if ! asdf plugin-list | grep -Fq "$name"; then
-    asdf plugin-add "$name" "$url"
+  if ! asdf plugin list | grep -Fq "$name"; then
+    asdf plugin add "$name" "$url"
   else
-    asdf plugin-update "$name"
+    asdf plugin update "$name"
   fi
 }
 
@@ -190,7 +190,7 @@ add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 install_asdf_language() {
   local language="$1"
   local version
-  version="$(asdf list-all "$language" | grep -v "[a-z]" | tail -1)"
+  version="$(asdf list all "$language" | grep -v "[a-z]" | tail -1)"
 
   if ! asdf list "$language" | grep -Fq "$version"; then
     asdf install "$language" "$version"


### PR DESCRIPTION
👋 I wanted to upstream some fixes.

Since the last time I ran the script, there have been some breaking changes with the latest versions of `asdf`.

The [hyphenated commands have been removed](https://asdf-vm.com/guide/upgrading-to-v0-16.html#hyphenated-commands-have-been-removed) and [asdf global and asdf local commands have been replaced with asdf set](https://asdf-vm.com/guide/upgrading-to-v0-16.html#asdf-global-and-asdf-local-commands-have-been-replaced-with-asdf-set). The `list` command now includes a trailing newline, which will be trimmed. I also added `brew upgrade asdf` if it is already installed.

- [x] Updated CHANGELOG
- [ ] Updated README.md (if necessary)
