### PR TITLE
task: remove deprecated tap

### DIFF
--- a/mac
+++ b/mac
@@ -121,7 +121,6 @@ fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
-tap "homebrew/services"
 tap "heroku/brew"
 
 # Unix


### PR DESCRIPTION
>homebrew/services was deprecated. This tap is now empty and all its contents were either deleted or migrated.

A description of your change.

- [ ] Updated CHANGELOG
- [ ] Updated README.md (if necessary)
