### PR TITLE
✨ Add `fzf` installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ macOS tools:
 
 Unix tools:
 
+* [fzf][] for better command history searching
 * [Universal Ctags] for indexing files for vim tab completion
 * [Git] for version control
 * [OpenSSL] for Transport Layer Security (TLS)
@@ -80,6 +81,7 @@ Unix tools:
 * [Watchman] for watching for filesystem events
 * [Zsh] as your shell
 
+[fzf]: https://github.com/junegunn/fzf
 [Universal Ctags]: https://ctags.io/
 [Git]: https://git-scm.com/
 [OpenSSL]: https://www.openssl.org/

--- a/mac
+++ b/mac
@@ -125,6 +125,7 @@ tap "heroku/brew"
 
 # Unix
 brew "universal-ctags"
+brew "fzf"
 brew "git"
 brew "openssl"
 brew "rcm"


### PR DESCRIPTION
Before, `dotfiles` configured `fzf` for Vim, but `laptop` didn't install it. We ended up with a dependency gap. Developers need `fzf` for the enhanced file and history searching that `dotfiles` expect. For clarity, we added an `fzf` installation.
