### PR TITLE
🔧 Make the script upgrade dependencies

### DIFF
--- a/mac
+++ b/mac
@@ -214,3 +214,6 @@ if [ -f "$HOME/.laptop.local" ]; then
   # shellcheck disable=SC1091
   . "$HOME/.laptop.local"
 fi
+
+fancy_echo "Upgrading Homebrew casks and formulae…"
+brew upgrade


### PR DESCRIPTION
Before, we installed all the recommended dependencies. We never automated the updating of them, though. Our dependencies soon became outdated. We made the script upgrade those dependencies.
