### PR TITLE
Sync with upstream thoughtbot/laptop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## Unreleased
+
+## 2024-10-21
+
+* Added Discord
+* Removed
+  * Wireguard Tools
+  * Firefox
+  * Hugo
 
 ## 2024-09-24
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,11 +10,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Support for macOS Sequoia
 
+## 2024-01-17
+
+* Updated for my personal usage
+
 ## 2023-10-03
 
 ### Added
 
 * Support for macOS Sonoma
+
+## 2023-04-24
+
+### Changed
+
+* [Adds Rosetta 2 in case a macbook has M1 architecture](https://github.com/thoughtbot/laptop/pull/628)
 
 ## 2022-12-02
 
@@ -38,9 +48,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [Ignore shellcheck warning SC3043 globally](https://github.com/thoughtbot/laptop/pull/606)
 * [Use gpg-suite-no-mail](https://github.com/thoughtbot/laptop/pull/607)
 * [Update ctags installation command](https://github.com/thoughtbot/laptop/pull/586)
-
-## 2023-04-24
-
-### Changed
-
-* [Adds Rosetta 2 in case a macbook has M1 architecture](https://github.com/thoughtbot/laptop/pull/628)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a personal fork of [thoughtbot/laptop](https://github.com/thoughtbot/laptop) — a shell script that automates macOS development environment setup. The entire installation logic lives in a single file: `mac`.
+
+## Running the Script
+
+```sh
+# Install/update the full environment
+sh mac 2>&1 | tee ~/laptop.log
+
+# Lint the script
+shellcheck mac
+```
+
+The script is idempotent and safe to run multiple times.
+
+## Architecture
+
+The `mac` script is a single ~280-line shell script with this flow:
+
+1. **Helper functions** — `fancy_echo`, `append_to_zshrc`, `gem_install_or_update`, `update_shell`, `add_or_update_asdf_plugin`, `install_asdf_language`
+2. **Environment setup** — creates `~/.bin`, detects Homebrew prefix (arm64: `/opt/homebrew`, Intel: `/usr/local`), installs Rosetta 2 on Apple Silicon
+3. **Homebrew + Brewfile** — inline `Brewfile` block (lines ~123–197) runs `brew bundle` to install all taps, formulae, and casks
+4. **Shell config** — installs Oh My Zsh and Starship prompt, appends configuration to `~/.zshrc`
+5. **Language versions** — installs latest Ruby and Node.js via asdf
+6. **Zsh plugins** — autosuggestions, history-substring-search, syntax-highlighting
+7. **User customizations** — sources `~/.laptop.local` at the end if it exists
+
+## Key Conventions
+
+- **Architecture detection**: uses `$(uname -m)` to branch between arm64 and Intel paths — keep this pattern when adding architecture-specific steps.
+- **Homebrew bundle**: all packages are declared in the inline heredoc Brewfile within the `mac` script — add new tools there, not separately.
+- **Persona comments**: some casks are annotated `# Home laptop only` — preserve these to track device-specific decisions.
+- **User extensions**: `~/.laptop.local` is the supported override point; don't hardcode personal overrides into `mac` itself.
+
+## Testing
+
+Test on a clean macOS install using UTM (included as a cask). There are no automated tests for the script itself.

--- a/README.md
+++ b/README.md
@@ -242,4 +242,5 @@ We are [available for hire][hire].
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
 
+
 <!-- END /templates/footer.md -->

--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ Read through it to see if you can debug the issue yourself.
 General tools and applications:
 
 * [Homebrew] for managing operating system libraries.
-* 1password
-* Firefox
+* [1Password] for password management
+* [Discord] for personal and tech community chat
 
 [Homebrew]: http://brew.sh/
+[1Password]: https://1password.com/
+[Discord]: https://discord.com/
 
 Unix tools:
 
@@ -111,23 +113,32 @@ Databases:
 
 General development tools and applications:
 
-* exa as an `ls` replacement
-* overmind
-* Terminal and Zsh tools
-* Firefox Developer Edition
-* iterm2
-* Visual Studio Code
+* [exa] as an `ls` replacement
+* [overmind] for managing Procfile-based applications
+* Terminal and Zsh tools (autocompletion, syntax highlighting, history search, etc.)
+* [Firefox Developer Edition]
+* [iterm2] for a better terminal experience
+* [Visual Studio Code] editor
+
+[exa]: https://the.exa.website/
+[overmind]: https://github.com/DarthSim/overmind
+[Firefox Developer Edition]: https://www.mozilla.org/en-US/firefox/developer/
+[iterm2]: https://iterm2.com/
+[Visual Studio Code]: https://code.visualstudio.com/
 
 Personal development tools and applications (can be on TD laptop):
 
-* exercism for programming exercises
-* flyctl for deploying to Fly.io
-* utm for running macOS in a virtual machine (and testing this script...)
+* [exercism] for programming exercises
+* [flyctl] for deploying to Fly.io
+* [utm] for running macOS in a virtual machine (and testing this script...)
+
+[exercism]: https://exercism.io/
+[flyctl]: https://fly.io/docs/flyctl/
+[utm]: https://mac.getutm.app
 
 Test Double Tools and applications:
 
 * [Heroku CLI]
-* Hugo
 * Slack
 
 [Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli
@@ -217,8 +228,6 @@ Tip: Make a fresh virtual machine with the installation of macOS completed and
 your user created and first launch complete. Then duplicate that machine to test
 the script each time on a fresh install thats ready to go.
 
-[UTM]: https://mac.getutm.app
-
 ## License
 
 Copyright © 2011 thoughtbot, inc.
@@ -241,6 +250,5 @@ We are [available for hire][hire].
 
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
-
 
 <!-- END /templates/footer.md -->

--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ Databases:
 
 General development tools and applications:
 
-* [exa] as an `ls` replacement
+* [eza] as an `ls` replacement
 * [overmind] for managing Procfile-based applications
 * Terminal and Zsh tools (autocompletion, syntax highlighting, history search, etc.)
 * [Firefox Developer Edition]
 * [iterm2] for a better terminal experience
 * [Visual Studio Code] editor
 
-[exa]: https://the.exa.website/
+[eza]: https://eza.rocks
 [overmind]: https://github.com/DarthSim/overmind
 [Firefox Developer Edition]: https://www.mozilla.org/en-US/firefox/developer/
 [iterm2]: https://iterm2.com/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-Laptop
-======
+# Laptop
+
+This is a fork of [thoughtbot/laptop](<https://github.com/thoughtbot/laptop>) modified for my personal laptop setup.
 
 Laptop is a script to set up a macOS laptop for web and mobile development.
 
@@ -7,8 +8,7 @@ It can be run multiple times on the same machine safely.
 It installs, upgrades, or skips packages
 based on what is already installed on the machine.
 
-Requirements
-------------
+## Requirements
 
 We support:
 
@@ -20,19 +20,12 @@ We support:
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.
 
-Install
--------
+## Install
 
 Download the script:
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/thoughtbot/laptop/main/mac
-```
-
-Review the script (avoid running scripts you haven't read!):
-
-```sh
-less mac
+curl --remote-name https://raw.githubusercontent.com/czeise/laptop/main/mac
 ```
 
 Execute the downloaded script:
@@ -47,60 +40,46 @@ Optionally, review the log:
 less ~/laptop.log
 ```
 
-Optionally, [install thoughtbot/dotfiles][dotfiles].
+[Install dotfiles][dotfiles].
 
-[dotfiles]: https://github.com/thoughtbot/dotfiles#install
+[dotfiles]: https://github.com/czeise/dotfiles#install
 
-Debugging
----------
+## Debugging
 
 Your last Laptop run will be saved to `~/laptop.log`.
 Read through it to see if you can debug the issue yourself.
-If not, copy the lines where the script failed into a
-[new GitHub Issue](https://github.com/thoughtbot/laptop/issues/new) for us.
-Or, attach the whole log file as an attachment.
 
-What it sets up
----------------
+## What it sets up
 
-macOS tools:
+General tools and applications:
 
 * [Homebrew] for managing operating system libraries.
+* 1password
+* Firefox
 
 [Homebrew]: http://brew.sh/
 
 Unix tools:
 
-* [Universal Ctags] for indexing files for vim tab completion
 * [Git] for version control
 * [OpenSSL] for Transport Layer Security (TLS)
-* [RCM] for managing company and personal dotfiles
+* [RCM] for managing dotfiles
 * [The Silver Searcher] for finding things in files
 * [Tmux] for saving project state and switching between projects
-* [Watchman] for watching for filesystem events
 * [Zsh] as your shell
 
-[Universal Ctags]: https://ctags.io/
 [Git]: https://git-scm.com/
 [OpenSSL]: https://www.openssl.org/
 [RCM]: https://github.com/thoughtbot/rcm
 [The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
 [Tmux]: http://tmux.github.io/
-[Watchman]: https://facebook.github.io/watchman/
 [Zsh]: http://www.zsh.org/
 
-Heroku tools:
-
-* [Heroku CLI] and [Parity] for interacting with the Heroku API
-
-[Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli
-[Parity]: https://github.com/thoughtbot/parity
-
-GitHub tools:
+<!-- GitHub tools:
 
 * [GitHub CLI] for interacting with the GitHub API
 
-[GitHub CLI]: https://cli.github.com/
+[GitHub CLI]: https://cli.github.com/ -->
 
 Image tools:
 
@@ -113,7 +92,6 @@ Programming languages, package managers, and configuration:
 * [Node.js] and [npm], for running apps and installing JavaScript packages
 * [Ruby] stable for writing general-purpose code
 * [Yarn] for managing JavaScript packages
-* [Rosetta 2] for running tools that are not supported in Apple silicon processors
 
 [Bundler]: http://bundler.io/
 [ImageMagick]: http://www.imagemagick.org/
@@ -122,7 +100,6 @@ Programming languages, package managers, and configuration:
 [asdf-vm]: https://github.com/asdf-vm/asdf
 [Ruby]: https://www.ruby-lang.org/en/
 [Yarn]: https://yarnpkg.com/en/
-[Rosetta 2]: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
 
 Databases:
 
@@ -132,10 +109,32 @@ Databases:
 [Postgres]: http://www.postgresql.org/
 [Redis]: http://redis.io/
 
+General development tools and applications:
+
+* exa as an `ls` replacement
+* overmind
+* Terminal and Zsh tools
+* Firefox Developer Edition
+* iterm2
+* Visual Studio Code
+
+Personal development tools and applications (can be on TD laptop):
+
+* exercism for programming exercises
+* flyctl for deploying to Fly.io
+* utm for running macOS in a virtual machine (and testing this script...)
+
+Test Double Tools and applications:
+
+* [Heroku CLI]
+* Hugo
+* Slack
+
+[Heroku CLI]: https://devcenter.heroku.com/articles/heroku-cli
+
 It should take less than 15 minutes to install (depends on your machine).
 
-Customize in `~/.laptop.local`
-------------------------------
+## Customize in `~/.laptop.local`
 
 Your `~/.laptop.local` is run at the end of the Laptop script.
 Put your customizations there.
@@ -186,8 +185,7 @@ can be used in your `~/.laptop.local`.
 See the [wiki](https://github.com/thoughtbot/laptop/wiki)
 for more customization examples.
 
-Contributing
-------------
+## Contributing
 
 Thank you, [contributors]!
 
@@ -221,8 +219,7 @@ the script each time on a fresh install thats ready to go.
 
 [UTM]: https://mac.getutm.app
 
-License
--------
+## License
 
 Copyright © 2011 thoughtbot, inc.
 It is free software,
@@ -244,6 +241,5 @@ We are [available for hire][hire].
 
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
-
 
 <!-- END /templates/footer.md -->

--- a/mac
+++ b/mac
@@ -79,6 +79,22 @@ case "$SHELL" in
     ;;
 esac
 
+# Rosetta 2
+#
+# Note: This is currently only needed for ddpm. Remove if no longer needed.
+if [ "$(uname -m)" = "arm64" ]
+  then
+  # checks if Rosetta is already installed
+  if ! pkgutil --pkg-info=com.apple.pkg.RosettaUpdateAuto > /dev/null 2>&1
+  then
+    echo "Installing Rosetta"
+    # Installs Rosetta2
+    softwareupdate --install-rosetta --agree-to-license
+  else
+    echo "Rosetta is installed"
+  fi
+fi
+
 gem_install_or_update() {
   if gem list "$1" --installed > /dev/null; then
     gem update "$@"
@@ -107,10 +123,24 @@ brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
 tap "homebrew/services"
 tap "heroku/brew"
+brew "mas" # mas-cli to install macOS apps, doesn't work with utm
 
 # General
 cask "1password"
+cask "1password-cli"
+cask "lunar"
 cask "discord" # Using both for personal and work laptop setups
+mas "AdGuard for Safari", id: 1440147259
+mas "1Password for Safari", id: 1569813296
+mas "Magnet", id: 441258766
+mas "com.kagimacOS.Kagi-Search", id: 1622835804
+cask "spotify"
+
+# Hardware related apps
+cask "ddpm"
+cask "logi-options+" # Logitech mice and keyboards
+cask "logitune" # Logitech cameras
+mas "HP Smart", id: 1474276998 # HP printers
 
 # Unix
 brew "git"
@@ -138,12 +168,16 @@ brew "redis", restart_service: :changed
 brew "eza"
 brew "overmind"
 brew "terminal-notifier"
+brew "starship"
 brew "zsh-autosuggestions"
 brew "zsh-history-substring-search"
 brew "zsh-syntax-highlighting"
 cask "firefox@developer-edition"
+cask "font-jetbrains-mono"
 cask "iterm2"
 cask "visual-studio-code"
+cask "tableplus"
+cask "bruno"
 
 # Personal development (can be on TD laptop)
 brew "exercism"
@@ -152,26 +186,25 @@ cask "utm"
 
 # Test Double
 cask "slack"
+cask "notion"
 brew "heroku/brew/heroku"
+cask "zoom"
+
+# Home laptop only
+mas "Bear", id: 1091189122
+# TODO: Add Todoist
+cask "idrive"
 EOF
 
-fancy_echo "Install Oh My Zsh ..."
+fancy_echo "Installing Oh My Zsh ..."
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
   sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+  sh -c "$(cat ~/.zshrc.pre-oh-my-zsh >> ~/.zshrc)"
 fi
 
-fancy_echo "Install Oh My Zsh plugins ..."
-if [ -d $HOMEBREW_PREFIX/share/zsh-autosuggestions ]; then
-  append_to_zshrc 'source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh'
-fi
-
-if [ -d $HOMEBREW_PREFIX/share/zsh-history-substring-search ]; then
-  append_to_zshrc 'source $(brew --prefix)/share/zsh-history-substring-search/zsh-history-substring-search.zsh'
-fi
-
-if [ -d $HOMEBREW_PREFIX/share/zsh-syntax-highlighting ]; then
-  append_to_zshrc 'source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh'
-fi
+fancy_echo "Add Starship init script to ~/.zshrc ..."
+append_to_zshrc "# Starship init script"
+append_to_zshrc 'eval "$(starship init zsh)"' 1
 
 fancy_echo "Update heroku binary ..."
 brew unlink heroku
@@ -180,6 +213,7 @@ brew link --force heroku
 fancy_echo "Configuring asdf version manager ..."
 if [ ! -d "$HOME/.asdf" ]; then
   brew install asdf
+  append_to_zshrc "# asdf version manager"
   append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
 fi
 
@@ -219,6 +253,23 @@ bundle config --global jobs $((number_of_cores - 1))
 
 fancy_echo "Installing latest Node ..."
 install_asdf_language "nodejs"
+
+fancy_echo "Installing Oh My Zsh plugins ..."
+if [ -d $HOMEBREW_PREFIX/share/zsh-autosuggestions ]; then
+  # assumption: If zsh-autosuggestions isn't installed, then none of the other
+  # plugins are installed, and I can add this comment on the top to group them
+  # together nicely
+  append_to_zshrc "# Oh My Zsh plugins"
+  append_to_zshrc "source $HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh" 1
+fi
+
+if [ -d $HOMEBREW_PREFIX/share/zsh-history-substring-search ]; then
+  append_to_zshrc "source $HOMEBREW_PREFIX/share/zsh-history-substring-search/zsh-history-substring-search.zsh" 1
+fi
+
+if [ -d $HOMEBREW_PREFIX/share/zsh-syntax-highlighting ]; then
+  append_to_zshrc "source $HOMEBREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" 1
+fi
 
 if [ -f "$HOME/.laptop.local" ]; then
   fancy_echo "Running your customizations from ~/.laptop.local ..."

--- a/mac
+++ b/mac
@@ -79,21 +79,6 @@ case "$SHELL" in
     ;;
 esac
 
-# checks architecture
-if [ "$(uname -m)" = "arm64" ]
-  then
-  # checks if Rosetta is already installed
-  if ! pkgutil --pkg-info=com.apple.pkg.RosettaUpdateAuto > /dev/null 2>&1
-  then
-    echo "Installing Rosetta"
-    # Installs Rosetta2
-    softwareupdate --install-rosetta --agree-to-license
-  else
-    echo "Rosetta is installed"
-  fi
-fi
-
-
 gem_install_or_update() {
   if gem list "$1" --installed > /dev/null; then
     gem update "$@"
@@ -120,45 +105,75 @@ fi
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "thoughtbot/formulae"
+tap "homebrew/cask-versions"
 tap "homebrew/services"
 tap "heroku/brew"
 
+# General
+cask "1password"
+cask "firefox"
+
 # Unix
-brew "universal-ctags"
 brew "git"
 brew "openssl"
 brew "rcm"
-brew "reattach-to-user-namespace"
 brew "the_silver_searcher"
 brew "tmux"
-brew "vim"
-brew "watchman"
 brew "zsh"
 
-# Heroku
-brew "heroku/brew/heroku"
-brew "parity"
-
 # GitHub
-brew "gh"
+# brew "gh"
 
 # Image manipulation
 brew "imagemagick"
 
-# PDF Rendering
-brew "poppler"
-
 # Programming language prerequisites and package managers
-brew "libyaml" # should come after openssl
-brew "coreutils"
 brew "yarn"
 cask "gpg-suite-no-mail"
 
 # Databases
-brew "postgresql@14", restart_service: :changed
+brew "postgresql", restart_service: :changed
 brew "redis", restart_service: :changed
+
+# Development tools
+brew "exa"
+brew "overmind"
+brew "terminal-notifier"
+brew "zsh-autosuggestions"
+brew "zsh-history-substring-search"
+brew "zsh-syntax-highlighting"
+cask "firefox-developer-edition"
+cask "iterm2"
+cask "visual-studio-code"
+
+# Personal development (can be on TD laptop)
+brew "exercism"
+brew "flyctl"
+cask "utm"
+
+# Test Double
+cask "slack"
+brew "heroku"
+brew "hugo"
 EOF
+
+fancy_echo "Install Oh My Zsh ..."
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+fi
+
+fancy_echo "Install Oh My Zsh plugins ..."
+if [ -d $HOMEBREW_PREFIX/share/zsh-autosuggestions ]; then
+  append_to_zshrc 'source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh'
+fi
+
+if [ -d $HOMEBREW_PREFIX/share/zsh-history-substring-search ]; then
+  append_to_zshrc 'source $(brew --prefix)/share/zsh-history-substring-search/zsh-history-substring-search.zsh'
+fi
+
+if [ -d $HOMEBREW_PREFIX/share/zsh-syntax-highlighting ]; then
+  append_to_zshrc 'source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh'
+fi
 
 fancy_echo "Update heroku binary ..."
 brew unlink heroku

--- a/mac
+++ b/mac
@@ -110,6 +110,7 @@ tap "homebrew/services"
 tap "heroku/brew"
 
 # General
+brew "wireguard-tools"
 cask "1password"
 cask "firefox"
 

--- a/mac
+++ b/mac
@@ -110,9 +110,8 @@ tap "homebrew/services"
 tap "heroku/brew"
 
 # General
-brew "wireguard-tools"
 cask "1password"
-cask "firefox"
+cask "discord" # Using both for personal and work laptop setups
 
 # Unix
 brew "git"
@@ -155,7 +154,6 @@ cask "utm"
 # Test Double
 cask "slack"
 brew "heroku"
-brew "hugo"
 EOF
 
 fancy_echo "Install Oh My Zsh ..."

--- a/mac
+++ b/mac
@@ -105,7 +105,6 @@ fi
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "homebrew/cask-versions"
 tap "homebrew/services"
 tap "heroku/brew"
 
@@ -132,17 +131,17 @@ brew "yarn"
 cask "gpg-suite-no-mail"
 
 # Databases
-brew "postgresql", restart_service: :changed
+brew "postgresql@17", restart_service: :changed
 brew "redis", restart_service: :changed
 
 # Development tools
-brew "exa"
+brew "eza"
 brew "overmind"
 brew "terminal-notifier"
 brew "zsh-autosuggestions"
 brew "zsh-history-substring-search"
 brew "zsh-syntax-highlighting"
-cask "firefox-developer-edition"
+cask "firefox@developer-edition"
 cask "iterm2"
 cask "visual-studio-code"
 
@@ -153,7 +152,7 @@ cask "utm"
 
 # Test Double
 cask "slack"
-brew "heroku"
+brew "heroku/brew/heroku"
 EOF
 
 fancy_echo "Install Oh My Zsh ..."


### PR DESCRIPTION
## Summary

- Merges latest upstream changes from thoughtbot/laptop (commits through `1d3f29f`)
- Resolves conflicts preserving personal customizations

## Changes from upstream

- Add `fzf` for better command history searching
- Remove deprecated `homebrew/services` tap (now integrated into brew)
- Update asdf CLI to new command syntax (`plugin list/add/update`, `list all`)
- Upgrade asdf when already installed (`brew upgrade asdf`)
- Use `asdf set --home` instead of deprecated `asdf global`

## Conflict resolutions

- Kept our Brewfile additions; dropped `thoughtbot/formulae` tap and `universal-ctags` (both intentionally removed in our config)
- Added upstream's `fzf` entry to README Unix tools section; omitted `Universal Ctags` since we don't install it

🤖 Generated with [Claude Code](https://claude.com/claude-code)