### PR TITLE
Install parity as a gem instead of via Homebrew

### DIFF
--- a/mac
+++ b/mac
@@ -138,7 +138,6 @@ brew "zsh"
 
 # Heroku
 brew "heroku/brew/heroku"
-brew "parity"
 
 # GitHub
 brew "gh"
@@ -205,6 +204,7 @@ install_asdf_language "ruby"
 gem update --system
 number_of_cores=$(sysctl -n hw.ncpu)
 bundle config --global jobs $((number_of_cores - 1))
+gem_install_or_update "parity"
 
 fancy_echo "Installing latest Node ..."
 install_asdf_language "nodejs"


### PR DESCRIPTION
This PR replaces `brew "parity"` with `gem_install_or_update "parity"` in the `mac` script. The Homebrew is no longer available and causes `brew bundle` to fail during setup. Parity is now installed as a gem.

Closes #663