### PR TITLE
Fix asdf issue on clean installs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## 2026-07-01
+
+* Fixes asdf installs, now compatible with asdf >= 16 (released 2025-01-30)
+
 ## 2025-07-09
 
 * Removed deprecated homebrew/services tap

--- a/mac
+++ b/mac
@@ -166,7 +166,11 @@ brew link --force heroku
 fancy_echo "Configuring asdf version manager ..."
 if [ ! -d "$HOME/.asdf" ]; then
   brew install asdf
-  append_to_zshrc "source $(brew --prefix asdf)/libexec/asdf.sh" 1
+  # for future runs
+  # shellcheck disable=SC2016
+  append_to_zshrc 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"'
+  # for this session, so we don't need to restart the shell to do stuff with asdf
+  export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 else
   brew upgrade asdf
 fi
@@ -184,7 +188,6 @@ add_or_update_asdf_plugin() {
 }
 
 # shellcheck disable=SC1091
-. "$(brew --prefix asdf)/libexec/asdf.sh"
 add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 


### PR DESCRIPTION
Clean installs fails due to asdf >= 16 not being function based, but rather a binary.  See commit message for details.

Verified using clean install runs on MacOS Tahoe via UTM.

- [x] Updated CHANGELOG